### PR TITLE
Testing with cloud-services-config

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -1,0 +1,89 @@
+const { resolve } = require('path');
+const webpack = require('webpack');
+const config = require('@redhat-cloud-services/frontend-components-config');
+
+const { config: webpackConfig, plugins } = config({
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  ...(process.env.BETA && { deployment: 'beta/apps' }),
+  ...(process.env.PROXY && {
+    https: true,
+    useProxy: true,
+    proxyVerbose: true,
+    env: `${process.env.ENVIRONMENT || 'stage'}-${
+      process.env.BETA ? 'beta' : 'stable'
+    }`, // for accessing prod-beta start your app with ENVIRONMENT=prod and BETA=true
+    appUrl: process.env.BETA
+      ? '/beta/staging/starter'
+      : '/staging/starter',
+    routes: {
+      ...(process.env.CONFIG_PORT && {
+        [`${process.env.BETA ? '/beta' : ''}/config`]: {
+          host: `http://localhost:${process.env.CONFIG_PORT}`,
+        },
+      }),
+      ...(process.env.LOCAL_API && {
+        ...(process.env.LOCAL_API.split(',') || []).reduce((acc, curr) => {
+          const [appName, appConfig] = (curr || '').split(':');
+          const [appPort = 8003, protocol = 'http'] = appConfig.split('~');
+          return {
+            ...acc,
+            [`/apps/${appName}`]: {
+              host: `${protocol}://localhost:${appPort}`,
+            },
+            [`/insights/${appName}`]: {
+              host: `${protocol}://localhost:${appPort}`,
+            },
+            [`/beta/insights/${appName}`]: {
+              host: `${protocol}://localhost:${appPort}`,
+            },
+            [`/beta/apps/${appName}`]: {
+              host: `${protocol}://localhost:${appPort}`,
+            },
+          };
+        }, {}),
+      }),
+    },
+  }),
+});
+
+plugins.push(
+  require('@redhat-cloud-services/frontend-components-config/federated-modules')(
+    {
+      root: resolve(__dirname, '../'),
+      useFileHash: false,
+      exposes: {
+        // Application root
+        './RootApp': resolve(__dirname, '../src/AppEntry'),
+      },
+    }
+  )
+);
+
+plugins.push(
+  new webpack.DefinePlugin({
+    IS_DEV: true,
+  })
+);
+
+webpackConfig.resolve.alias = {
+  ...webpackConfig.resolve.alias,
+  reactRedux: resolve(__dirname, '../node_modules/react-redux'),
+};
+
+webpackConfig.module.rules = [
+  ...webpackConfig.module.rules,
+  {
+    test: /\.m?js/,
+    resolve: {
+      fullySpecified: false,
+    },
+  },
+];
+
+webpackConfig.devServer.client.overlay = false;
+
+module.exports = {
+  ...webpackConfig,
+  plugins,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "frontend-starter-app",
-  "version": "1.1.0",
+  "name": "hybrid-committed-spend",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend-starter-app",
-      "version": "1.1.0",
+      "name": "hybrid-committed-spend",
+      "version": "0.0.1",
       "dependencies": {
-        "@patternfly/react-core": "4.192.7",
-        "@patternfly/react-table": "4.61.7",
-        "@redhat-cloud-services/frontend-components": "^3.9.5",
-        "@redhat-cloud-services/frontend-components-notifications": "^3.2.8",
-        "@redhat-cloud-services/frontend-components-utilities": "^3.2.21",
+        "@patternfly/react-core": "4.231.8",
+        "@patternfly/react-table": "4.100.8",
+        "@redhat-cloud-services/frontend-components": "^3.9.9",
+        "@redhat-cloud-services/frontend-components-notifications": "^3.2.9",
+        "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
         "classnames": "^2.3.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -2692,14 +2692,14 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.192.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.192.7.tgz",
-      "integrity": "sha512-rTqe8jlzYd2/BZnCH01W1kOIr/53gWtGjIZAt9IdfLkdK1F4lyDFWKHf5cu6H5Kf3bk/hlN+DbmAldckF5xbVw==",
+      "version": "4.231.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.231.8.tgz",
+      "integrity": "sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.43.7",
-        "@patternfly/react-styles": "^4.42.7",
-        "@patternfly/react-tokens": "^4.44.7",
-        "focus-trap": "6.2.2",
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
+        "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
@@ -2710,28 +2710,28 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.72.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.72.3.tgz",
-      "integrity": "sha512-bZCPsOsxtFXTmZQqDKNebkBywud3E0ID3446AWI1RO5Ypufdc0FTkehSzBPANfJPYjjK9/EYaIy8rF0yiJdFPQ==",
+      "version": "4.82.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.82.8.tgz",
+      "integrity": "sha512-cKixprTiMLZRe/+kmdZ5suvYb9ly9p1f/HjlcNiWBfsiA8ZDEPmxJnVdend/YsafelC8YC9QGcQf97ay5PNhcw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.71.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.71.3.tgz",
-      "integrity": "sha512-JpMBIrJfco3JwK9KbJvjr+tKZidVhbkGrQT7GyWbYAwZ2bOmCmeCPJYc0xhAWcvNumn9a7AhYzAWPJVlQQue3g=="
+      "version": "4.81.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.81.8.tgz",
+      "integrity": "sha512-Q5FiureSSCMIuz+KLMcEm1317TzbXcwmg2q5iNDRKyf/K+5CT6tJp0Wbtk3FlfRvzli4u/7YfXipahia5TL+tA=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "4.61.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.61.7.tgz",
-      "integrity": "sha512-Ca8/W/roCMVuUpFqSavQHqoJ3z7mGEEJQ/i1wUeoyYPhXMIlmM+hjeWNfDGdpDcw22txGG/4FAlCHTP6QMHLiQ==",
+      "version": "4.100.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.100.8.tgz",
+      "integrity": "sha512-80XZCZzoYN9gsoufNdXUB/dk33SuWF9lUnOJs7ilezD6noTSD7ARqO1h532eaEPIbPBp4uIVkEUdfGSHd0HJtg==",
       "dependencies": {
-        "@patternfly/react-core": "^4.192.7",
-        "@patternfly/react-icons": "^4.43.7",
-        "@patternfly/react-styles": "^4.42.7",
-        "@patternfly/react-tokens": "^4.44.7",
+        "@patternfly/react-core": "^4.231.8",
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       },
@@ -2741,9 +2741,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "4.73.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.73.3.tgz",
-      "integrity": "sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg=="
+      "version": "4.83.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.83.8.tgz",
+      "integrity": "sha512-Z/MHXNY8PQOuBFGUar2yzPVbz3BNJuhB+Dnk5RJcc/iIn3S+VlSru7g6v5jqoV/+a5wLqZtLGEBp8uhCZ7Xkig=="
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.21",
@@ -2770,9 +2770,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.5.tgz",
-      "integrity": "sha512-N6YP003wLQa+JVHWnhZPNw2QSlUSgkAu3g9H9zXg7wZfPV1KknBekm6wazq7Sk9qbgPnydiOtZMH1eZOwuXStg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.9.tgz",
+      "integrity": "sha512-qatmn0b4GKQ8ieZ0AqDh9+nHS3dYy+ouA9naisCaCSlO7iAR0eqfSJK6+lWOySzkNy+fZk317ur6PwbvjMgt/Q==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
         "@redhat-cloud-services/types": "^0.0.5",
@@ -2923,9 +2923,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.8.tgz",
-      "integrity": "sha512-dnq2lonGFXNcTT8MILjr7/Q8UGAFmvwzl+JB7Ufqtv+OT4JwfRHABNgDZfMiDVCqMWCb4P062/1RuxBdbWX53g==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.9.tgz",
+      "integrity": "sha512-SCWtDvNabTb3hZ2dxXHgl2nhGShT/ORsWfhUh7G4kxnjIADOUBGQLEmVrN5HTYdAyCRsFsPpp4PbiJKLGEz1YA==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "redux-promise-middleware": "6.1.2"
@@ -2943,9 +2943,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.21.tgz",
-      "integrity": "sha512-VsCfNM/gY4CNZVobKnoSd8GZ7lYOsvCwoCZgNZThbehGYwL6JukB92o9Vqu4ysflps3PXGOoU1fwGxt4xEhhyA==",
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.24.tgz",
+      "integrity": "sha512-7FDAnJ8+LbQY6w+d0WTIFaxObkY6bIzKRGcCBtqw/safntqqcRg1fKRTy/sHNrWisgEFHkOJ6XxlsHtBLgmWfw==",
       "dependencies": {
         "@redhat-cloud-services/types": "^0.0.5",
         "@sentry/browser": "^5.4.0",
@@ -7912,11 +7912,11 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
-      "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
+      "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
       "dependencies": {
-        "tabbable": "^5.1.4"
+        "tabbable": "^5.3.2"
       }
     },
     "node_modules/follow-redirects": {
@@ -19602,47 +19602,47 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.192.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.192.7.tgz",
-      "integrity": "sha512-rTqe8jlzYd2/BZnCH01W1kOIr/53gWtGjIZAt9IdfLkdK1F4lyDFWKHf5cu6H5Kf3bk/hlN+DbmAldckF5xbVw==",
+      "version": "4.231.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.231.8.tgz",
+      "integrity": "sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
       "requires": {
-        "@patternfly/react-icons": "^4.43.7",
-        "@patternfly/react-styles": "^4.42.7",
-        "@patternfly/react-tokens": "^4.44.7",
-        "focus-trap": "6.2.2",
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
+        "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.72.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.72.3.tgz",
-      "integrity": "sha512-bZCPsOsxtFXTmZQqDKNebkBywud3E0ID3446AWI1RO5Ypufdc0FTkehSzBPANfJPYjjK9/EYaIy8rF0yiJdFPQ==",
+      "version": "4.82.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.82.8.tgz",
+      "integrity": "sha512-cKixprTiMLZRe/+kmdZ5suvYb9ly9p1f/HjlcNiWBfsiA8ZDEPmxJnVdend/YsafelC8YC9QGcQf97ay5PNhcw==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.71.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.71.3.tgz",
-      "integrity": "sha512-JpMBIrJfco3JwK9KbJvjr+tKZidVhbkGrQT7GyWbYAwZ2bOmCmeCPJYc0xhAWcvNumn9a7AhYzAWPJVlQQue3g=="
+      "version": "4.81.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.81.8.tgz",
+      "integrity": "sha512-Q5FiureSSCMIuz+KLMcEm1317TzbXcwmg2q5iNDRKyf/K+5CT6tJp0Wbtk3FlfRvzli4u/7YfXipahia5TL+tA=="
     },
     "@patternfly/react-table": {
-      "version": "4.61.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.61.7.tgz",
-      "integrity": "sha512-Ca8/W/roCMVuUpFqSavQHqoJ3z7mGEEJQ/i1wUeoyYPhXMIlmM+hjeWNfDGdpDcw22txGG/4FAlCHTP6QMHLiQ==",
+      "version": "4.100.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.100.8.tgz",
+      "integrity": "sha512-80XZCZzoYN9gsoufNdXUB/dk33SuWF9lUnOJs7ilezD6noTSD7ARqO1h532eaEPIbPBp4uIVkEUdfGSHd0HJtg==",
       "requires": {
-        "@patternfly/react-core": "^4.192.7",
-        "@patternfly/react-icons": "^4.43.7",
-        "@patternfly/react-styles": "^4.42.7",
-        "@patternfly/react-tokens": "^4.44.7",
+        "@patternfly/react-core": "^4.231.8",
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.73.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.73.3.tgz",
-      "integrity": "sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg=="
+      "version": "4.83.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.83.8.tgz",
+      "integrity": "sha512-Z/MHXNY8PQOuBFGUar2yzPVbz3BNJuhB+Dnk5RJcc/iIn3S+VlSru7g6v5jqoV/+a5wLqZtLGEBp8uhCZ7Xkig=="
     },
     "@polka/url": {
       "version": "1.0.0-next.21",
@@ -19665,9 +19665,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.5.tgz",
-      "integrity": "sha512-N6YP003wLQa+JVHWnhZPNw2QSlUSgkAu3g9H9zXg7wZfPV1KknBekm6wazq7Sk9qbgPnydiOtZMH1eZOwuXStg==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.9.tgz",
+      "integrity": "sha512-qatmn0b4GKQ8ieZ0AqDh9+nHS3dYy+ouA9naisCaCSlO7iAR0eqfSJK6+lWOySzkNy+fZk317ur6PwbvjMgt/Q==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": ">=3.0.0",
         "@redhat-cloud-services/types": "^0.0.5",
@@ -19780,9 +19780,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-notifications": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.8.tgz",
-      "integrity": "sha512-dnq2lonGFXNcTT8MILjr7/Q8UGAFmvwzl+JB7Ufqtv+OT4JwfRHABNgDZfMiDVCqMWCb4P062/1RuxBdbWX53g==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-3.2.9.tgz",
+      "integrity": "sha512-SCWtDvNabTb3hZ2dxXHgl2nhGShT/ORsWfhUh7G4kxnjIADOUBGQLEmVrN5HTYdAyCRsFsPpp4PbiJKLGEz1YA==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "*",
         "react-redux": ">=5.0.7",
@@ -19791,9 +19791,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.2.21",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.21.tgz",
-      "integrity": "sha512-VsCfNM/gY4CNZVobKnoSd8GZ7lYOsvCwoCZgNZThbehGYwL6JukB92o9Vqu4ysflps3PXGOoU1fwGxt4xEhhyA==",
+      "version": "3.2.24",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.2.24.tgz",
+      "integrity": "sha512-7FDAnJ8+LbQY6w+d0WTIFaxObkY6bIzKRGcCBtqw/safntqqcRg1fKRTy/sHNrWisgEFHkOJ6XxlsHtBLgmWfw==",
       "requires": {
         "@redhat-cloud-services/types": "^0.0.5",
         "@sentry/browser": "^5.4.0",
@@ -23682,11 +23682,11 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
-      "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
+      "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
       "requires": {
-        "tabbable": "^5.1.4"
+        "tabbable": "^5.3.2"
       }
     },
     "follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "frontend-starter-app",
-  "version": "1.1.0",
+  "name": "hybrid-committed-spend",
+  "version": "0.0.1",
   "private": false,
   "engines": {
     "node": ">=16.0.0",
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "fec build",
+    "build:dev": "npm run build",
     "deploy": "npm-run-all build lint test",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint config src",
@@ -15,15 +16,16 @@
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "patch:hosts": "fec patch-etc-hosts",
     "start": "fec dev",
+    "start:dev": "npm run start",
     "test": "jest",
     "verify": "npm-run-all build lint test"
   },
   "dependencies": {
-    "@patternfly/react-core": "4.192.7",
-    "@patternfly/react-table": "4.61.7",
-    "@redhat-cloud-services/frontend-components": "^3.9.5",
-    "@redhat-cloud-services/frontend-components-notifications": "^3.2.8",
-    "@redhat-cloud-services/frontend-components-utilities": "^3.2.21",
+    "@patternfly/react-core": "4.231.8",
+    "@patternfly/react-table": "4.100.8",
+    "@redhat-cloud-services/frontend-components": "^3.9.9",
+    "@redhat-cloud-services/frontend-components-notifications": "^3.2.9",
+    "@redhat-cloud-services/frontend-components-utilities": "^3.2.24",
     "classnames": "^2.3.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "lint:js:fix": "eslint config src --fix",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "patch:hosts": "fec patch-etc-hosts",
-    "start": "fec dev",
-    "start:dev": "npm run start",
+
+    "start": "fec static --config config/dev.webpack.config.js",
+    "start:dev": "CONFIG_PORT=8889 BETA=true PROXY=true npm run start",
+
     "test": "jest",
     "verify": "npm-run-all build lint test"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <title>Starter App</title>
+        <title>Hybrid Committed Spend</title>
         <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>


### PR DESCRIPTION
I want to test `cloud-services-config` with the "sample app" this project is based on. 

In order to add the required `http://localhost:8889` route, I copied `dev.webpack.config` from Inventory. I also created a `start:dev` target with a couple env vars, like so:

```
"start": "fec static --config config/dev.webpack.config.js",
"start:dev": "CONFIG_PORT=8889 BETA=true PROXY=true npm run start",
```

Unfortunately, I have not been able to reach https://stage.foo.redhat.com:1337/beta/staging/starter using this approach.
What am I missing?

Note that I was successful using the `webpack.config` file from Cost management. However, I'd like to use the Inventory approach if possible?