### PR TITLE
Fix full page error state

### DIFF
--- a/src/routes/overview/Overview.tsx
+++ b/src/routes/overview/Overview.tsx
@@ -36,10 +36,18 @@ const OverviewBase: React.FC<OverviewProps> = ({ hasReportErrors }) => {
   const isTest = true;
   return (
     <React.Fragment>
-      <OverviewHeader />
-      <Main>
-        <Suspense fallback={<Spinner />}>{!isTest && hasReportErrors ? <NotAvailable /> : <Dashboard />}</Suspense>
-      </Main>
+      {!isTest && hasReportErrors ? (
+        <NotAvailable />
+      ) : (
+        <>
+          <OverviewHeader />
+          <Main>
+            <Suspense fallback={<Spinner />}>
+              <Dashboard />
+            </Suspense>
+          </Main>
+        </>
+      )}
     </React.Fragment>
   );
 };


### PR DESCRIPTION
Should not see data in header when full page error is shown