### PR TITLE
Remove flagsReady hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,20 +4,17 @@ import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome'
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
-import { useFlagsStatus } from '@unleash/proxy-client-react';
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Reducer } from 'redux';
-import { Loading } from 'routes/state/loading';
 
 import pckg from '../package.json';
-import { FeatureFlags } from './components/feature-flags';
+import { useFeatureFlags } from './components/feature-flags';
 import { Routes } from './Routes';
 
 type Unregister = () => void;
 
 const App = () => {
-  const { flagsReady } = useFlagsStatus();
   const history = useHistory();
   const chrome = useChrome();
 
@@ -37,17 +34,14 @@ const App = () => {
     };
   }, [chrome]);
 
-  if (flagsReady) {
-    return (
-      <div className="hybrid-committed-spend">
-        <NotificationsPortal />
-        <FeatureFlags>
-          <Routes />
-        </FeatureFlags>
-      </div>
-    );
-  }
-  return <Loading />;
+  useFeatureFlags();
+
+  return (
+    <div className="hybrid-committed-spend">
+      <NotificationsPortal />
+      <Routes />
+    </div>
+  );
 };
 
 export default App;

--- a/src/components/feature-flags/FeatureFlags.tsx
+++ b/src/components/feature-flags/FeatureFlags.tsx
@@ -1,16 +1,7 @@
-import { Bullseye, Spinner } from '@patternfly/react-core';
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
-import { useFlagsStatus, useUnleashClient, useUnleashContext } from '@unleash/proxy-client-react';
-import React, { useLayoutEffect, useRef } from 'react';
+import { useUnleashClient, useUnleashContext } from '@unleash/proxy-client-react';
+import { useLayoutEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { featureFlagsActions } from 'store/feature-flags';
-
-interface FeatureFlagsOwnProps {
-  children?: React.ReactNode;
-}
-
-type FeatureFlagsProps = FeatureFlagsOwnProps & RouteComponentProps<void>;
 
 // eslint-disable-next-line no-shadow
 export const enum FeatureToggle {
@@ -26,9 +17,8 @@ if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.
 }
 
 // The FeatureFlags component saves feature flags in store for places where Unleash hooks not available
-const FeatureFlagsBase: React.FC<FeatureFlagsProps> = ({ children = null }) => {
+const useFeatureFlags = () => {
   const updateContext = useUnleashContext();
-  const { flagsReady } = useFlagsStatus();
   const client = useUnleashClient();
   const dispatch = useDispatch();
 
@@ -52,11 +42,7 @@ const FeatureFlagsBase: React.FC<FeatureFlagsProps> = ({ children = null }) => {
   useLayoutEffect(() => {
     // Wait for the new flags to pull in from the different context
     const fetchFlags = async () => {
-      // eslint-disable-next-line no-console
-      console.log('*** In fetchFlags (waiting...)', userId);
       await updateContext({ userId }).then(() => {
-        // eslint-disable-next-line no-console
-        console.log('*** In updateContext (DONE)', userId);
         dispatch(
           featureFlagsActions.setFeatureFlags({
             isDetailsFeatureEnabled: client.isEnabled(FeatureToggle.details),
@@ -68,22 +54,6 @@ const FeatureFlagsBase: React.FC<FeatureFlagsProps> = ({ children = null }) => {
       fetchFlags();
     }
   });
-
-  // eslint-disable-next-line no-console
-  console.log('*** flagsReady?', flagsReady);
-
-  if (flagsReady) {
-    return <>{children}</>;
-  }
-  return (
-    <Main>
-      <Bullseye>
-        <Spinner />
-      </Bullseye>
-    </Main>
-  );
 };
 
-const FeatureFlags = withRouter(FeatureFlagsBase);
-
-export default FeatureFlags;
+export default useFeatureFlags;

--- a/src/components/feature-flags/index.ts
+++ b/src/components/feature-flags/index.ts
@@ -1,1 +1,1 @@
-export { default as FeatureFlags, FeatureToggle } from './FeatureFlags';
+export { default as useFeatureFlags, FeatureToggle } from './FeatureFlags';


### PR DESCRIPTION
Remove Unleash's flagsReady hook.

This does not appear to be doing anything as it's always true. And don't want to block the UI from rendering, considering the UI will update when Redux dispatches flag events.

https://issues.redhat.com/browse/COST-3089