### PR TITLE
Refactor details page to use PatternFly's composable, expandable table

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -339,7 +339,7 @@
     "dashboardActualSpendTitle": [
       {
         "type": 0,
-        "value": "Actual spend of included products YTD"
+        "value": "Actual spend contract YTD"
       }
     ],
     "dashboardCommitmentSpendTitle": [

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -21,7 +21,7 @@
   "contractDate": "Contract dates: {dateRange}",
   "currencyAbbreviations": "{symbol, select, billion {{value} B} million {{value} M} quadrillion {{value} q} thousand {{value} K} trillion {{value} t} other {}}",
   "dashboardActualSpendBreakdownTitle": "Actual spend breakdowns",
-  "dashboardActualSpendTitle": "Actual spend of included products YTD",
+  "dashboardActualSpendTitle": "Actual spend contract YTD",
   "dashboardCommitmentSpendTitle": "Remaining commitment balance",
   "dashboardCommitmentSpendTrendTitle": "Committed spend trend",
   "dateRange": "{value, select, contracted_ytd {Contracted YTD} contracted_last_year {Past contracted year (dates)} date {date - date contracted year} last_nine_months {Last 9 months} last_six_months {Last 6 months} last_three_months {Last 3 months} other {}}",

--- a/src/api/reports/accountSummaryReports.ts
+++ b/src/api/reports/accountSummaryReports.ts
@@ -6,7 +6,6 @@ import { ReportType } from './report';
 export interface AccountSummaryReportData extends ReportData {
   account_name?: string;
   account_number?: string;
-  actualSpend?: ReportValue; // Todo: for testing
   contract_start_date?: string;
   contract_end_date?: string;
   consumption_date?: string;

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -129,8 +129,8 @@ export default defineMessages({
     id: 'dashboardActualSpendBreakdownTitle',
   },
   dashboardActualSpendTitle: {
-    defaultMessage: 'Actual spend of included products YTD',
-    description: 'Actual spend of included products YTD',
+    defaultMessage: 'Actual spend contract YTD',
+    description: 'Actual spend contract YTD',
     id: 'dashboardActualSpendTitle',
   },
   dashboardCommitmentSpendTitle: {

--- a/src/routes/details/Details.tsx
+++ b/src/routes/details/Details.tsx
@@ -6,6 +6,7 @@ import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
 import messages from 'locales/messages';
+import { cloneDeep } from 'lodash';
 import React, { lazy, Suspense, useMemo, useState } from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
@@ -147,6 +148,7 @@ const Details: React.FC<DetailsProps> = ({ history, intl }) => {
         }
         query={query}
         report={report}
+        secondaryGroupBy={secondaryGroupBy}
       />
     );
   };
@@ -260,17 +262,17 @@ const mapToProps = ({ dateRange, groupBy = baseQuery.group_by }: DetailsOwnProps
     let result;
     switch (groupBy) {
       case GroupByType.affiliate:
-        result = affiliateData;
+        result = cloneDeep(affiliateData);
         break;
       case GroupByType.account:
-        result = accountData;
+        result = cloneDeep(accountData);
         break;
       case GroupByType.sourceOfSpend:
-        result = sourceData;
+        result = cloneDeep(sourceData);
         break;
       case GroupByType.product:
       default:
-        result = productData;
+        result = cloneDeep(productData);
         break;
     }
 

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -117,7 +117,7 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
         label={intl.formatMessage(messages.secondaryGroupByLabel)}
         minWidth={200}
         onSelected={handleOnSecondaryGroupBySelected}
-        options={secondaryGroupByOptions}
+        options={secondaryGroupByOptions.filter(option => option.value !== groupBy)}
       />
       <Perspective
         currentItem={dateRange}

--- a/src/routes/details/DetailsTable.scss
+++ b/src/routes/details/DetailsTable.scss
@@ -8,5 +8,14 @@
         padding-left: 0;
       }
     }
+    .pf-c-table__expandable-row {
+      --pf-c-table--cell--PaddingTop: var(--pf-c-table--tbody--cell--PaddingTop);
+      --pf-c-table--cell--PaddingBottom: var(--pf-c-table--tbody--cell--PaddingBottom);
+      &.pf-m-expanded > :first-child {
+        --pf-c-table--cell--PaddingLeft: 72px;
+        --pf-c-table__expandable-row--after--BorderLeftWidth: 0;
+      }
+    }
   }
 }
+

--- a/src/routes/details/DetailsTableExpand.tsx
+++ b/src/routes/details/DetailsTableExpand.tsx
@@ -1,0 +1,266 @@
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Td, Th, Tr } from '@patternfly/react-table';
+import type { Query } from 'api/queries';
+import { getQuery, parseQuery } from 'api/queries';
+import type { Report } from 'api/reports/report';
+import { ReportPathsType, ReportType } from 'api/reports/report';
+import type { AxiosError } from 'axios';
+import messages from 'locales/messages';
+import { cloneDeep } from 'lodash';
+import React, { useEffect, useMemo, useState } from 'react';
+import type { WrappedComponentProps } from 'react-intl';
+import { injectIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import type { RouteComponentProps } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+import { getDateRange, getDateRangeDefault } from 'routes/utils/dateRange';
+import type { RootState } from 'store';
+import { FetchStatus } from 'store/common';
+import { reportActions, reportSelectors } from 'store/reports';
+import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { formatCurrency } from 'utils/format';
+
+import { accountData } from './data/accountData';
+import { affiliateData } from './data/affiliateData';
+import { productData } from './data/productData';
+import { sourceData } from './data/sourceData';
+import type { DetailsTableCell } from './DetailsTable';
+import { reportItem, reportItemValue } from './DetailsTable';
+import { GroupByType } from './utils';
+
+interface DetailsTableExpandOwnProps {
+  columns?: any[];
+  dateRange?: string;
+  groupBy?: string;
+  groupByValue?: string;
+  isExpanded?: boolean;
+  isHidden?: boolean;
+  rowIndex?: number;
+  secondaryGroupBy?: string;
+  setRowIndex?: (rowIndex: number, callback) => any;
+}
+
+interface DetailsTableExpandStateProps {
+  end_date?: string;
+  query: Query;
+  queryString: string;
+  report: Report;
+  reportError: AxiosError;
+  reportFetchStatus: FetchStatus;
+  start_date?: string;
+}
+
+type DetailsTableExpandProps = DetailsTableExpandOwnProps & RouteComponentProps<void> & WrappedComponentProps;
+
+export const baseQuery: Query = {
+  filter: {
+    limit: 10,
+    offset: 0,
+  },
+  filter_by: {},
+  group_by: {
+    product: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+const reportPathsType = ReportPathsType.details; // Todo: temporary placeholder for upcoming API
+const reportType = ReportType.cost;
+
+const DetailsTableExpandBase: React.FC<DetailsTableExpandProps> = ({
+  columns,
+  dateRange,
+  groupBy,
+  groupByValue,
+  intl,
+  isExpanded,
+  secondaryGroupBy,
+}) => {
+  const [rows, setRows] = useState([]);
+  const { report, reportFetchStatus } = mapToProps({ dateRange, groupBy, groupByValue, secondaryGroupBy });
+
+  const initDatum = () => {
+    if (!report) {
+      return;
+    }
+
+    const computedItems = getUnsortedComputedReportItems({
+      report,
+      idKey: secondaryGroupBy,
+      isDateMap: true,
+    });
+
+    // Sort by date and fill in missing row cells
+    const newRows = [];
+    computedItems.map(rowItem => {
+      const cells: DetailsTableCell[] = [];
+      let value; // For first column resource name
+
+      const items: any = Array.from(rowItem.values()).sort((a: any, b: any) => {
+        if (new Date(a.date) > new Date(b.date)) {
+          return 1;
+        } else if (new Date(a.date) < new Date(b.date)) {
+          return -1;
+        } else {
+          return 0;
+        }
+      });
+
+      items.map(item => {
+        if (!value) {
+          value = item && item.label && item.label !== null ? item.label : null;
+        }
+
+        // Add row cells
+        cells.push({
+          value:
+            item[reportItem] && item[reportItem][reportItemValue]
+              ? formatCurrency(item[reportItem][reportItemValue].value, item[reportItem][reportItemValue].units)
+              : intl.formatMessage(messages.chartNoData),
+        });
+      });
+
+      // Add first row cell (i.e., name)
+      cells.unshift({ value });
+      newRows.push(cells);
+    });
+
+    setRows(newRows);
+  };
+
+  useEffect(() => {
+    initDatum();
+  }, [report]);
+
+  return (
+    <React.Fragment>
+      {reportFetchStatus === FetchStatus.inProgress && isExpanded ? (
+        <Tr>
+          <Td colSpan={100}>
+            <Bullseye>
+              <div style={{ textAlign: 'center' }}>
+                <Spinner size="xl" />
+              </div>
+            </Bullseye>
+          </Td>
+        </Tr>
+      ) : (
+        rows.map((cells, rowIndex) => (
+          <React.Fragment key={`row-${rowIndex}`}>
+            <Tr isExpanded={isExpanded}>
+              {cells.map((item, cellIndex) =>
+                cellIndex === 0 ? (
+                  <Th
+                    dataLabel={columns[cellIndex]}
+                    key={`expanded-cell-${cellIndex}-${rowIndex}`}
+                    hasRightBorder
+                    isStickyColumn
+                  >
+                    <span className="expandedCol">{item.value}</span>
+                  </Th>
+                ) : (
+                  <Td dataLabel={columns[cellIndex]} key={`cell-${rowIndex}-${cellIndex}`}>
+                    {item.value}
+                  </Td>
+                )
+              )}
+            </Tr>
+          </React.Fragment>
+        ))
+      )}
+    </React.Fragment>
+  );
+};
+
+const mapToProps = ({
+  dateRange,
+  groupBy,
+  groupByValue,
+  secondaryGroupBy,
+}: DetailsTableExpandOwnProps): DetailsTableExpandStateProps => {
+  const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
+
+  const queryFromRoute = parseQuery<Query>(location.search);
+  const _dateRange = dateRange || getDateRangeDefault(queryFromRoute);
+  const { end_date, start_date } = getDateRange(_dateRange);
+
+  const query = {
+    filter: {
+      [groupBy]: groupByValue,
+    },
+    filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
+    group_by: secondaryGroupBy,
+    order_by: queryFromRoute.order_by,
+  };
+  const queryString = getQuery({
+    ...query,
+    dateRange: undefined,
+    end_date,
+    start_date,
+  });
+
+  const report = useSelector((/* state: RootState */) => {
+    // reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queryString)
+
+    let result;
+    switch (secondaryGroupBy) {
+      case GroupByType.affiliate:
+        result = cloneDeep(affiliateData);
+        break;
+      case GroupByType.account:
+        result = cloneDeep(accountData);
+        break;
+      case GroupByType.sourceOfSpend:
+        result = cloneDeep(sourceData);
+        break;
+      case GroupByType.product:
+      default:
+        result = cloneDeep(productData);
+        break;
+    }
+
+    const startDate = new Date(start_date + 'T23:59:59z');
+    const endDate = new Date(end_date + 'T23:59:59z');
+    endDate.setMonth(endDate.getMonth() + 1);
+
+    result.data = result.data.filter(item => {
+      const currentDate = new Date(item.date + 'T23:59:59z');
+      if (currentDate >= startDate && currentDate <= endDate) {
+        return item;
+      }
+    });
+
+    return result;
+  });
+  const reportFetchStatus = useSelector((state: RootState) =>
+    reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString)
+  );
+  const reportError = useSelector((state: RootState) =>
+    reportSelectors.selectReportError(state, reportPathsType, reportType, queryString)
+  );
+
+  useMemo(() => {
+    if (reportFetchStatus !== FetchStatus.inProgress) {
+      // Todo: simulate time to fetch
+      dispatch(reportActions.fetchReport(reportPathsType, reportType, queryString));
+    }
+  }, [queryString]);
+
+  return {
+    end_date,
+    query,
+    queryString,
+    report,
+    reportFetchStatus,
+    reportError,
+    start_date,
+  };
+};
+
+const DetailsTableExpand = injectIntl(withRouter(DetailsTableExpandBase));
+
+export { DetailsTableExpand };

--- a/src/routes/details/data/accountData.ts
+++ b/src/routes/details/data/accountData.ts
@@ -830,7 +830,6 @@ export const accountData = {
         },
       ],
     },
-
     {
       date: '2022-01',
       accounts: [
@@ -2791,6 +2790,498 @@ export const accountData = {
                 },
                 total: {
                   value: 25755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-09',
+      accounts: [
+        {
+          account: 'OpenShift Container Platform',
+          values: [
+            {
+              date: '2022-09',
+              account: 'OpenShift Container Platform',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 23392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 23392.2000140326872,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 27136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 27136,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 23392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 27136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2210528.200014032687,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          account: 'Insights for RHEL',
+          values: [
+            {
+              date: '2022-09',
+              account: 'Insights for RHEL',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 2797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22293.9787,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 23091.145754555068,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22064.61,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 2394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22458.741035988717,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 2797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 24358.5887,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 2394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 25549.886790543785,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          account: 'Ansible Engine',
+          values: [
+            {
+              date: '2022-09',
+              account: 'Ansible Engine',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 221619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 221619.181524760065,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 24136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 24136.77,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 221619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 24136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 25755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-10',
+      accounts: [
+        {
+          account: 'OpenShift Container Platform',
+          values: [
+            {
+              date: '2022-10',
+              account: 'OpenShift Container Platform',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 2939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2939.9514813845437,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 28944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22944,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 2939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 28944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 23883.9514813845435,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          account: 'Insights for RHEL',
+          values: [
+            {
+              date: '2022-10',
+              account: 'Insights for RHEL',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 256.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 221546.3948,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 221596.50830541913,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 221436.54,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 221436.54,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 256.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22382.9348,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22433.04830541913,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          account: 'Ansible Engine',
+          values: [
+            {
+              date: '2022-10',
+              account: 'Ansible Engine',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 22179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22179.70350866113299,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22312.64,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 22179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22432.343508661133,
                   units: 'USD',
                 },
               },

--- a/src/routes/details/data/accountData.ts
+++ b/src/routes/details/data/accountData.ts
@@ -3044,6 +3044,7 @@ export const accountData = {
         },
       ],
     },
+    /*
     {
       date: '2022-10',
       accounts: [
@@ -3290,5 +3291,7 @@ export const accountData = {
         },
       ],
     },
+
+     */
   ],
 };

--- a/src/routes/details/data/affiliateData.ts
+++ b/src/routes/details/data/affiliateData.ts
@@ -3044,6 +3044,7 @@ export const affiliateData = {
         },
       ],
     },
+    /*
     {
       date: '2022-10',
       affiliates: [
@@ -3290,5 +3291,7 @@ export const affiliateData = {
         },
       ],
     },
+
+     */
   ],
 };

--- a/src/routes/details/data/affiliateData.ts
+++ b/src/routes/details/data/affiliateData.ts
@@ -830,7 +830,6 @@ export const affiliateData = {
         },
       ],
     },
-
     {
       date: '2022-01',
       affiliates: [
@@ -2791,6 +2790,498 @@ export const affiliateData = {
                 },
                 total: {
                   value: 15755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-09',
+      affiliates: [
+        {
+          affiliate: 'ACME - Anvils',
+          values: [
+            {
+              date: '2022-09',
+              affiliate: 'ACME - Anvils',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 13392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 13392.2000140326872,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 17136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 17136,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 13392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 17136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 110528.200014032687,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          affiliate: 'ACME - Fireworks',
+          values: [
+            {
+              date: '2022-09',
+              affiliate: 'ACME - Fireworks',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 1797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 12293.9787,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 13091.145754555068,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 12064.61,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 1394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 12458.741035988717,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 1797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 14358.5887,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 1394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 15549.886790543785,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          affiliate: 'ACME - Tunnels',
+          values: [
+            {
+              date: '2022-09',
+              affiliate: 'ACME - Tunnels',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 11619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 11619.181524760065,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 14136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 14136.77,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 11619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 14136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 15755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-10',
+      affiliates: [
+        {
+          affiliate: 'ACME - Anvils',
+          values: [
+            {
+              date: '2022-10',
+              affiliate: 'ACME - Anvils',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 1939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 1939.9514813845437,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 18944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 12944,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 1939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 18944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 13883.9514813845435,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          affiliate: 'ACME - Fireworks',
+          values: [
+            {
+              date: '2022-10',
+              affiliate: 'ACME - Fireworks',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 156.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 11546.3948,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 11596.50830541913,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 11436.54,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 11436.54,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 156.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 12382.9348,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 12433.04830541913,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          affiliate: 'ACME - Tunnels',
+          values: [
+            {
+              date: '2022-10',
+              affiliate: 'ACME - Tunnels',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 1179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 1179.70350866113299,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 12312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 12312.64,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 1179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 12312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 12432.343508661133,
                   units: 'USD',
                 },
               },

--- a/src/routes/details/data/productData.ts
+++ b/src/routes/details/data/productData.ts
@@ -3044,6 +3044,7 @@ export const productData = {
         },
       ],
     },
+    /*
     {
       date: '2022-10',
       products: [
@@ -3290,5 +3291,7 @@ export const productData = {
         },
       ],
     },
+
+     */
   ],
 };

--- a/src/routes/details/data/productData.ts
+++ b/src/routes/details/data/productData.ts
@@ -830,7 +830,6 @@ export const productData = {
         },
       ],
     },
-
     {
       date: '2022-01',
       products: [
@@ -2791,6 +2790,498 @@ export const productData = {
                 },
                 total: {
                   value: 25755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-09',
+      products: [
+        {
+          product: 'OpenShift Container Platform',
+          values: [
+            {
+              date: '2022-09',
+              product: 'OpenShift Container Platform',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 23392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 23392.2000140326872,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 27136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 27136,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 23392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 27136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2210528.200014032687,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          product: 'Insights for RHEL',
+          values: [
+            {
+              date: '2022-09',
+              product: 'Insights for RHEL',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 2797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22293.9787,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 23091.145754555068,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22064.61,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 2394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22458.741035988717,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 2797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 24358.5887,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 2394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 25549.886790543785,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          product: 'Ansible Engine',
+          values: [
+            {
+              date: '2022-09',
+              product: 'Ansible Engine',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 221619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 221619.181524760065,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 24136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 24136.77,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 221619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 24136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 25755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-10',
+      products: [
+        {
+          product: 'OpenShift Container Platform',
+          values: [
+            {
+              date: '2022-10',
+              product: 'OpenShift Container Platform',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 2939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2939.9514813845437,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 28944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22944,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 2939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 28944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 23883.9514813845435,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          product: 'Insights for RHEL',
+          values: [
+            {
+              date: '2022-10',
+              product: 'Insights for RHEL',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 256.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 221546.3948,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 221596.50830541913,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 221436.54,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 221436.54,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 256.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22382.9348,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22433.04830541913,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          product: 'Ansible Engine',
+          values: [
+            {
+              date: '2022-10',
+              product: 'Ansible Engine',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 22179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22179.70350866113299,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22312.64,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 22179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 22312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 22432.343508661133,
                   units: 'USD',
                 },
               },

--- a/src/routes/details/data/sourceData.ts
+++ b/src/routes/details/data/sourceData.ts
@@ -3042,6 +3042,7 @@ export const sourceData = {
         },
       ],
     },
+    /*
     {
       date: '2022-10',
       source_of_spends: [
@@ -3288,5 +3289,7 @@ export const sourceData = {
         },
       ],
     },
+
+     */
   ],
 };

--- a/src/routes/details/data/sourceData.ts
+++ b/src/routes/details/data/sourceData.ts
@@ -828,7 +828,6 @@ export const sourceData = {
         },
       ],
     },
-
     {
       date: '2022-01',
       source_of_spends: [
@@ -2789,6 +2788,498 @@ export const sourceData = {
                 },
                 total: {
                   value: 5755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-09',
+      source_of_spends: [
+        {
+          source_of_spend: 'Yearly Subs',
+          values: [
+            {
+              date: '2022-09',
+              source_of_spend: 'Yearly Subs',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 3392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 3392.2000140326872,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 7136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 7136,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 3392.2000140326872,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 7136,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 10528.200014032687,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          source_of_spend: 'Insights for RHEL',
+          values: [
+            {
+              date: '2022-09',
+              source_of_spend: 'Insights for RHEL',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 2293.9787,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 3091.145754555068,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 2064.61,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2458.741035988717,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 797.1670545550679,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 4358.5887,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 394.13103598871703,
+                  units: 'USD',
+                },
+                total: {
+                  value: 5549.886790543785,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          source_of_spend: 'Reseller / Distributor',
+          values: [
+            {
+              date: '2022-09',
+              source_of_spend: 'Reseller / Distributor',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 1619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 1619.181524760065,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 4136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 4136.77,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 1619.181524760065,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 4136.77,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 5755.951524760065,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      date: '2022-10',
+      source_of_spends: [
+        {
+          source_of_spend: 'Yearly Subs',
+          values: [
+            {
+              date: '2022-10',
+              source_of_spend: 'Yearly Subs',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 939.9514813845437,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 8944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2944,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 939.9514813845437,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 8944,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 3883.9514813845435,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          source_of_spend: 'Insights for RHEL',
+          values: [
+            {
+              date: '2022-10',
+              source_of_spend: 'Insights for RHEL',
+              source_uuid: [
+                '1899fc34-7096-47d6-82d8-e371268530b1',
+                '7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c',
+                'a99443de-af6d-4b4b-a1d9-fdeea529606d',
+                'ae7cd5c5-b6b8-4059-966d-0548287cb609',
+              ],
+              clusters: [
+                'OpenShift on AWS - Nise Populator',
+                'OpenShift on Azure - Nise Populator',
+                'OpenShift on GCP - Nise Populator',
+                'OpenShift on OpenStack - Nise Populator',
+              ],
+              infrastructure: {
+                raw: {
+                  value: 56.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 1546.3948,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 1596.50830541913,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 1436.54,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 1436.54,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 56.11350541913017,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 2382.9348,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2433.04830541913,
+                  units: 'USD',
+                },
+              },
+            },
+          ],
+        },
+        {
+          source_of_spend: 'Reseller / Distributor',
+          values: [
+            {
+              date: '2022-10',
+              source_of_spend: 'Reseller / Distributor',
+              source_uuid: ['7b2cf7da-d494-4f4d-b640-f9fa57a0fe1c', 'a99443de-af6d-4b4b-a1d9-fdeea529606d'],
+              clusters: ['OpenShift on AWS - Nise Populator', 'OpenShift on GCP - Nise Populator'],
+              infrastructure: {
+                raw: {
+                  value: 179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 0,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 179.70350866113299,
+                  units: 'USD',
+                },
+              },
+              supplementary: {
+                raw: {
+                  value: 0,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 2312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2312.64,
+                  units: 'USD',
+                },
+              },
+              cost: {
+                raw: {
+                  value: 179.70350866113299,
+                  units: 'USD',
+                },
+                markup: {
+                  value: 0,
+                  units: 'USD',
+                },
+                usage: {
+                  value: 2312.64,
+                  units: 'USD',
+                },
+                distributed: {
+                  value: 0,
+                  units: 'USD',
+                },
+                total: {
+                  value: 2432.343508661133,
                   units: 'USD',
                 },
               },


### PR DESCRIPTION
- Add two months of data
- Adjust actual spend card title
- Remove unused property
- Omit group by selection from secondary group by
- Omit current month from data
- Clone data, so it's not modified when date range is selected
- Override composable table styles
- Refactor to use PatternFly's composable, expandable table