### PR TITLE
Convert timestamps to support Firefox

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -365,14 +365,6 @@
               }
             ]
           },
-          "contracted_year": {
-            "value": [
-              {
-                "type": 0,
-                "value": "Contracted year"
-              }
-            ]
-          },
           "contracted_ytd": {
             "value": [
               {

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -24,7 +24,7 @@
   "dashboardActualSpendTitle": "Actual spend contract YTD",
   "dashboardCommitmentSpendTitle": "Remaining commitment balance",
   "dashboardCommitmentSpendTrendTitle": "Committed spend trend",
-  "dateRange": "{value, select, contracted_ytd {Contracted YTD} contracted_last_year {Past contracted year} contracted_year {Contracted year} last_nine_months {Last 9 months} last_six_months {Last 6 months} last_three_months {Last 3 months} other {}}",
+  "dateRange": "{value, select, contracted_ytd {Contracted YTD} contracted_last_year {Past contracted year} last_nine_months {Last 9 months} last_six_months {Last 6 months} last_three_months {Last 3 months} other {}}",
   "dateRangeLabel": "Time",
   "detailsEmptyState": "No data available",
   "detailsTableAriaLabel": "Details table",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -148,7 +148,6 @@ export default defineMessages({
       '{value, select, ' +
       'contracted_ytd {Contracted YTD} ' +
       'contracted_last_year {Past contracted year} ' +
-      'contracted_year {Contracted year} ' +
       'last_nine_months {Last 9 months} ' +
       'last_six_months {Last 6 months} ' +
       'last_three_months {Last 3 months} ' +

--- a/src/routes/components/charts/breakdown/BreakdownChart.tsx
+++ b/src/routes/components/charts/breakdown/BreakdownChart.tsx
@@ -91,7 +91,7 @@ const BreakdownChartBase: React.FC<BreakdownChartProps> = ({
               legendData={getLegendData(series, hiddenSeries, true)}
               title={datum =>
                 intl.formatMessage(messages.chartTooltipTitle, {
-                  value: intl.formatDate(`${datum.x}T23:59:59z`, {
+                  value: intl.formatDate(`${datum.x}T00:00:00`, {
                     month: 'long',
                     year: 'numeric',
                   }),
@@ -426,7 +426,7 @@ const BreakdownChartBase: React.FC<BreakdownChartProps> = ({
               if (isFloat(t) || isInt(t)) {
                 return t;
               }
-              return intl.formatDate(`${t}T23:59:59z`, {
+              return intl.formatDate(`${t}T00:00:00`, {
                 month: 'short',
                 year: 'numeric',
               });

--- a/src/routes/components/charts/common/chart-datum.ts
+++ b/src/routes/components/charts/common/chart-datum.ts
@@ -123,7 +123,7 @@ export function createReportDatum<T extends ComputedReportItem>({
   value,
 }: ReportData<T>): ChartDatum {
   const getDate = () => {
-    return new Date(`${computedItem.date}T23:59:59z`);
+    return new Date(`${computedItem.date}T00:00:00`);
   };
   const getXVal = () => {
     if (idKey === 'date' || shiftDateByYear > 0) {
@@ -201,8 +201,8 @@ export function getDateRange(datums: ChartDatum[]): [Date, Date] {
     }
   }
 
-  const start = new Date(`${datums[firstMonth].key}T23:59:59z`);
-  const end = new Date(`${datums[lastMonth].key}T23:59:59z`);
+  const start = new Date(`${datums[firstMonth].key}T00:00:00`);
+  const end = new Date(`${datums[lastMonth].key}T00:00:00`);
   return [start, end];
 }
 

--- a/src/routes/components/charts/trend/TrendChart.tsx
+++ b/src/routes/components/charts/trend/TrendChart.tsx
@@ -85,7 +85,7 @@ const TrendChartBase: React.FC<TrendChartProps> = ({
               legendData={getLegendData(series, hiddenSeries, true)}
               title={datum =>
                 intl.formatMessage(messages.chartTooltipTitle, {
-                  value: intl.formatDate(`${datum.key}T23:59:59z`, {
+                  value: intl.formatDate(`${datum.key}T00:00:00`, {
                     month: 'long',
                     ...(!previousData && { year: 'numeric' }),
                   }),
@@ -327,7 +327,7 @@ const TrendChartBase: React.FC<TrendChartProps> = ({
                 if (isFloat(t) || isInt(t)) {
                   return t;
                 }
-                return intl.formatDate(`${t}T23:59:59z`, {
+                return intl.formatDate(`${t}T00:00:00`, {
                   month: previousData ? 'long' : 'short',
                   ...(!previousData && { year: 'numeric' }),
                 });

--- a/src/routes/components/page-heading/PageHeading.tsx
+++ b/src/routes/components/page-heading/PageHeading.tsx
@@ -46,11 +46,11 @@ const PageHeading: React.FC<PageHeadingProps> = ({ children, intl }) => {
   const accountName: string | React.ReactNode = values && values.account_name ? values.account_name : emptyValue;
   const accountNumber: string | React.ReactNode = values && values.account_number ? values.account_number : emptyValue;
   const contractStartDate =
-    values && values.contract_start_date ? new Date(values.contract_start_date + 'T23:59:59z') : undefined;
+    values && values.contract_start_date ? new Date(values.contract_start_date + 'T00:00:00') : undefined;
   const contractEndDate =
-    values && values.contract_end_date ? new Date(values.contract_end_date + 'T23:59:59z') : undefined;
+    values && values.contract_end_date ? new Date(values.contract_end_date + 'T00:00:00') : undefined;
   const consumptionDate =
-    values && values.consumption_date ? new Date(values.consumption_date + 'T23:59:59z') : undefined;
+    values && values.consumption_date ? new Date(values.consumption_date + 'T00:00:00') : undefined;
 
   return (
     <PageHeader>

--- a/src/routes/details/Details.tsx
+++ b/src/routes/details/Details.tsx
@@ -235,7 +235,7 @@ const mapToProps = ({ dateRange, groupBy, sourcesOfSpend }: DetailsOwnProps): De
   const { summary } = accountSummaryMapToProps();
   const values = summary && summary.data && summary.data.length && summary.data[0];
   const contractStartDate =
-    values && values.contract_start_date ? new Date(values.contract_start_date + 'T23:59:59z') : undefined;
+    values && values.contract_start_date ? new Date(values.contract_start_date + 'T00:00:00') : undefined;
 
   const { endDate, query, report, reportFetchStatus, startDate } = detailsMapDateRangeToProps({
     contractStartDate,

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -33,7 +33,6 @@ const dateRangeOptions: PerspectiveOption[] = [
   { label: messages.dateRange, value: DateRangeType.lastSixMonths },
   { label: messages.dateRange, value: DateRangeType.lastNineMonths },
   { label: messages.dateRange, value: DateRangeType.contractedLastYear },
-  { label: messages.dateRange, value: DateRangeType.contractedYear },
 ];
 
 const groupByOptions: PerspectiveOption[] = [
@@ -87,11 +86,6 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
     return formatDateRange(startDate, endDate);
   };
 
-  const getContractedYearDateRange = () => {
-    const { endDate, startDate } = getDateRange(DateRangeType.contractedYear, contractStartDate);
-    return formatDateRange(startDate, endDate);
-  };
-
   const getContractedYtdDateRange = () => {
     const { endDate, startDate } = getDateRange(DateRangeType.contractedYtd, contractStartDate);
     return formatDateRange(startDate, endDate);
@@ -119,9 +113,6 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
       switch (option.value) {
         case DateRangeType.contractedLastYear:
           option.description = getContractedLastYearDateRange();
-          break;
-        case DateRangeType.contractedYear:
-          option.description = getContractedYearDateRange();
           break;
         case DateRangeType.contractedYtd:
           option.description = getContractedYtdDateRange();

--- a/src/routes/details/DetailsTable.scss
+++ b/src/routes/details/DetailsTable.scss
@@ -19,7 +19,7 @@
       --pf-c-table--cell--PaddingBottom: var(--pf-c-table--tbody--cell--PaddingBottom);
       &.pf-m-expanded > :first-child {
         --pf-c-table--cell--PaddingLeft: 72px;
-        --pf-c-table__expandable-row--after--BorderLeftWidth: 0;
+        // --pf-c-table__expandable-row--after--BorderLeftWidth: 0; // Left blue line for expanded rows
       }
     }
     .pf-c-table__sticky-column {

--- a/src/routes/details/api.ts
+++ b/src/routes/details/api.ts
@@ -177,7 +177,7 @@ export const detailsMapToProps = ({
 
     if (startDate && endDate) {
       result.data = result.data.filter(item => {
-        const currentDate = new Date(item.date + 'T23:59:59z');
+        const currentDate = new Date(item.date + 'T00:00:00');
         if (
           compareDateYearAndMonth(currentDate, startDate) >= 0 &&
           compareDateYearAndMonth(currentDate, endDate) <= 0

--- a/src/routes/details/data/productData.ts
+++ b/src/routes/details/data/productData.ts
@@ -16070,7 +16070,7 @@ export const productData = {
         },
       ],
     },
-    
+
  */
   ],
 };

--- a/src/routes/details/types.ts
+++ b/src/routes/details/types.ts
@@ -28,8 +28,6 @@ export function getDateRangeType(dateRange: DateRangeType): string {
       return 'contracted_ytd';
     case DateRangeType.contractedLastYear:
       return 'contracted_last_year';
-    case DateRangeType.contractedYear:
-      return 'contracted_year';
     case DateRangeType.lastNineMonths:
       return 'last_nine_months';
     case DateRangeType.lastSixMonths:

--- a/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownChart.tsx
+++ b/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownChart.tsx
@@ -32,8 +32,8 @@ export type ActualSpendBreakdownChartProps = ActualSpendBreakdownChartOwnProps &
 
 const ActualSpendBreakdownChartBase: React.FC<ActualSpendBreakdownChartProps> = ({ chartName, datumType, report }) => {
   const getChart = () => {
-    const startDate = new Date('2021-12-01T23:59:59z');
-    const endDate = new Date('2022-12-01T23:59:59z');
+    const startDate = new Date('2021-12-01T00:00:00');
+    const endDate = new Date('2022-12-01T00:00:00');
     const datums = getChartDatums(getComputedItems(), startDate, endDate);
 
     return (

--- a/src/routes/overview/components/actual-spend/ActualSpend.tsx
+++ b/src/routes/overview/components/actual-spend/ActualSpend.tsx
@@ -64,7 +64,7 @@ const ActualSpend: React.FC<ActualSpendProps> = ({ intl, widgetId }) => {
 
   let dateRange: string | React.ReactNode = <EmptyValueState />;
   if (values && values.contract_start_date) {
-    const startDate = new Date(values.contract_start_date + 'T23:59:59z');
+    const startDate = new Date(values.contract_start_date + 'T00:00:00');
     const endDate = getToday();
     endDate.setMonth(endDate.getMonth() - 1);
 

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendTransform.tsx
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendTransform.tsx
@@ -31,8 +31,8 @@ const CommittedSpendTrendTransformBase: React.FC<CommittedSpendTrendTransformPro
   thresholdReport,
 }) => {
   const getData = () => {
-    const startDate = new Date('2021-12-01T23:59:59z');
-    const endDate = new Date('2022-12-01T23:59:59z');
+    const startDate = new Date('2021-12-01T00:00:00');
+    const endDate = new Date('2022-12-01T00:00:00');
 
     const current = currentReport ? transformReport({ report: currentReport, startDate, endDate }) : undefined;
     const threshold = thresholdReport ? transformReport({ report: thresholdReport, startDate, endDate }) : undefined;

--- a/src/routes/overview/components/committed-spend/CommittedSpend.tsx
+++ b/src/routes/overview/components/committed-spend/CommittedSpend.tsx
@@ -57,7 +57,7 @@ const CommittedSpend: React.FC<CommittedSpendProps> = ({ intl, widgetId }) => {
   let dateRange: string | React.ReactNode = <EmptyValueState />;
   if (values && values.contract_end_date) {
     const startDate = getToday();
-    const endDate = new Date(values.contract_end_date + 'T23:59:59z');
+    const endDate = new Date(values.contract_end_date + 'T00:00:00');
 
     dateRange = intl.formatDateTimeRange(startDate, endDate, {
       month: 'long',

--- a/src/routes/utils/dateRange.ts
+++ b/src/routes/utils/dateRange.ts
@@ -1,6 +1,5 @@
 import {
   getContractedLastYear,
-  getContractedYear,
   getContractedYtd,
   getLastNineMonthsDate,
   getLastSixMonthsDate,
@@ -12,7 +11,6 @@ import {
 export const enum DateRangeType {
   contractedYtd = 'contracted_ytd', // Current month (Jan 1 - Dec 31)
   contractedLastYear = 'contracted_last_year', // Previous and current month (Dec 1 - Jan 18)
-  contractedYear = 'contracted_year', // Contracted year
   lastNineMonths = 'last_nine_months', // Last 90 days
   lastSixMonths = 'last_six_months', // Last 60 days (Nov 18 - Jan 17)
   lastThreeMonths = 'last_three_months', // Last 30 days (Dec 18 - Jan 17)
@@ -24,9 +22,6 @@ export const getDateRange = (dateRangeType: string, contractStartDate: Date = un
   switch (dateRangeType) {
     case DateRangeType.contractedLastYear:
       dateRange = getContractedLastYear(contractStartDate, isFormatted);
-      break;
-    case DateRangeType.contractedYear:
-      dateRange = getContractedYear(contractStartDate, isFormatted);
       break;
     case DateRangeType.contractedYtd:
       dateRange = getContractedYtd(contractStartDate, isFormatted);

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -18,7 +18,7 @@ export const compareDateYearAndMonth = (a: Date, b: Date) => {
 
 export const getDate = () => {
   const today = format(new Date(), 'yyyy-MM');
-  return new Date(`${today}T23:59:59z`);
+  return new Date(`${today}T00:00:00`);
 };
 
 export const getToday = (hrs: number = 0, min: number = 0, sec: number = 0) => {

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -63,14 +63,6 @@ export const getContractedLastYear = (startDate: Date = new Date(), isFormatted)
   return formatDate(_startDate, endDate, isFormatted);
 };
 
-export const getContractedYear = (startDate, isFormatted) => {
-  const endDate = new Date(startDate.getTime());
-  endDate.setDate(1); // Workaround to compare month properly
-  endDate.setMonth(endDate.getMonth() + 11);
-
-  return formatDate(startDate, endDate, isFormatted);
-};
-
 export const getContractedYtd = (startDate, isFormatted) => {
   const endDate = new Date();
   endDate.setDate(1); // Workaround to compare month properly


### PR DESCRIPTION
- Remove contracted year per UX review
- Add left blue line for expanded rows
- Convert timestamps from 'T23:59:59z' to 'T00:00:00' in order to work with Firefox