### PR TITLE
API changes

### DIFF
--- a/src/api/filters/filter.ts
+++ b/src/api/filters/filter.ts
@@ -14,8 +14,8 @@ export interface Filter extends PagedResponse<FilterData, FilterMeta> {}
 
 // eslint-disable-next-line no-shadow
 export const enum FilterType {
-  affiliate = 'affiliates', // Todo: current API uses plural here.
-  product = 'products', // Todo: current API uses plural here.
+  affiliate = 'affiliate',
+  product = 'product',
   sourceOfSpend = 'source_of_spend',
 }
 

--- a/src/routes/components/data-toolbar/DataToolbar.tsx
+++ b/src/routes/components/data-toolbar/DataToolbar.tsx
@@ -26,7 +26,6 @@ import React, { useEffect, useState } from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { FilterTypeahead } from 'routes/components/filterTypeahead';
-import { GroupByType } from 'routes/details/types';
 import type { Filter } from 'routes/utils/filter';
 import { usePrevious, useStateCallback } from 'utils/hooks';
 
@@ -106,12 +105,6 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
       return 'date';
     }
     for (const option of categoryOptions) {
-      // Todo: current API uses plural here.
-      if (groupBy === GroupByType.product || groupBy === GroupByType.affiliate) {
-        if (`${groupBy}s` === option.key) {
-          return option.key;
-        }
-      }
       if (groupBy === option.key) {
         return option.key;
       }
@@ -167,6 +160,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
         <InputGroup style={styles.categoryInput}>
           {isFilterTypeValid(filterPathsType, categoryOption.key as FilterType) ? (
             <FilterTypeahead
+              category={currentCategory}
               filterPathsType={filterPathsType}
               filterType={categoryOption.key as FilterType}
               isDisabled={isDisabled}

--- a/src/routes/components/filterTypeahead/filterInput.tsx
+++ b/src/routes/components/filterTypeahead/filterInput.tsx
@@ -31,6 +31,7 @@ import { useStateCallback } from 'utils/hooks';
 import { noop } from 'utils/noop';
 
 interface FilterInputOwnProps {
+  category?: string;
   isDisabled?: boolean;
   onClear?: () => void;
   onSearchChanged?: (value: string) => void;
@@ -52,6 +53,7 @@ interface FilterInputDispatchProps {
 type FilterInputProps = FilterInputOwnProps & FilterInputStateProps & FilterInputDispatchProps & WrappedComponentProps;
 
 const FilterInputBase: React.FC<FilterInputProps> = ({
+  category,
   filterPathsType,
   filterType,
   isDisabled,
@@ -67,6 +69,7 @@ const FilterInputBase: React.FC<FilterInputProps> = ({
   const textInputGroupRef = React.createRef<HTMLDivElement>();
 
   const { filter, filterFetchStatus } = useMapToProps({
+    category,
     filterPathsType,
     filterType,
     search,
@@ -231,13 +234,20 @@ const FilterInputBase: React.FC<FilterInputProps> = ({
   );
 };
 
-const useMapToProps = ({ filterPathsType, filterType, search }: FilterInputOwnProps): FilterInputStateProps => {
+const useMapToProps = ({
+  category,
+  filterPathsType,
+  filterType,
+  search,
+}: FilterInputOwnProps): FilterInputStateProps => {
   const [searchTimeout, setSearchTimeout] = useState(noop);
 
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
 
   const query: Query = {
-    productName: search, // Todo: API currently only supports productName param
+    filter: {
+      [category]: search,
+    },
   } as any;
   const filterQueryString = getQuery(query);
 

--- a/src/routes/components/filterTypeahead/filterTypeahead.tsx
+++ b/src/routes/components/filterTypeahead/filterTypeahead.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { FilterInput } from './filterInput';
 
 interface FilterTypeaheadOwnProps {
+  category?: string;
   filterPathsType: FilterPathsType;
   filterType: FilterType;
   isDisabled?: boolean;
@@ -14,7 +15,13 @@ type FilterTypeaheadProps = FilterTypeaheadOwnProps;
 
 // This wrapper provides text input value as the search prop for FilterInput.
 // This is used to create a query param to retrieve cached API requests.
-const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({ filterPathsType, filterType, isDisabled, onSelect }) => {
+const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({
+  category,
+  filterPathsType,
+  filterType,
+  isDisabled,
+  onSelect,
+}) => {
   const [search, setSearch] = useState(undefined);
 
   const handleOnClear = () => {
@@ -26,7 +33,7 @@ const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({ filterPathsType, filt
   };
 
   const handleOnSelect = (value: string) => {
-    setSearch(value);
+    setSearch(undefined);
     if (onSelect) {
       onSelect(value);
     }
@@ -34,6 +41,7 @@ const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({ filterPathsType, filt
 
   return (
     <FilterInput
+      category={category}
       isDisabled={isDisabled}
       onClear={handleOnClear}
       onSearchChanged={handleOnSearch}

--- a/src/routes/details/DetailsFilterToolbar.tsx
+++ b/src/routes/details/DetailsFilterToolbar.tsx
@@ -32,8 +32,8 @@ const DetailsFilterToolbarBase: React.FC<DetailsFilterToolbarProps> = ({
 }) => {
   const getCategoryOptions = (): ToolbarChipGroup[] => {
     return [
-      { name: intl.formatMessage(messages.filterByValues, { value: 'product' }), key: 'products' }, // Todo: current API uses plural here.
-      { name: intl.formatMessage(messages.filterByValues, { value: 'affiliate' }), key: 'affiliates' }, // Todo: current API uses plural here.
+      { name: intl.formatMessage(messages.filterByValues, { value: 'product' }), key: 'product' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'affiliate' }), key: 'affiliate' },
       { name: intl.formatMessage(messages.filterByValues, { value: 'source_of_spend' }), key: 'source_of_spend' },
     ];
   };

--- a/src/routes/details/utils.ts
+++ b/src/routes/details/utils.ts
@@ -159,24 +159,10 @@ export const useDetailsMapToProps = ({
     dateRange,
   };
 
-  // Todo: current API uses plurals for projects and affiliates.
-  const newQuery = { ...query };
-  if (groupBy === GroupByType.affiliate || groupBy === GroupByType.product) {
-    newQuery.primaryGroupBy = {
-      [`${groupBy}s`]: groupByValue ? groupByValue : '*',
-    };
-  }
-  // Todo: current API uses plurals for projects and affiliates.
-  if (secondaryGroupBy === GroupByType.affiliate || secondaryGroupBy === GroupByType.product) {
-    newQuery.secondaryGroupBy = {
-      [`${secondaryGroupBy}s`]: '*',
-    };
-  }
-
   const reportPathsType = ReportPathsType.details;
   const reportType = ReportType.billing;
   const reportQueryString = getQuery({
-    ...newQuery,
+    ...query,
     filter: {
       limit: 10,
       offset: 0,


### PR DESCRIPTION
Updated for latest details and detailsFilter API changes.

- group by singular names; project and affiliate
- detailsFilter now accepts project, affiliate, and source of spend