### PR TITLE
Show "Excess actual spend included" dynamically

### DIFF
--- a/src/routes/overview/components/actual-spend/ActualSpend.tsx
+++ b/src/routes/overview/components/actual-spend/ActualSpend.tsx
@@ -42,19 +42,18 @@ const ActualSpend: React.FC<ActualSpendProps> = ({ intl, widgetId }) => {
   const hasData = report && report.data && report.data.length;
   const values = hasData && report.data[0];
 
-  // Todo: replace with actual spend
   const actualCommittedSpend: string | React.ReactNode =
     values && values.actual_committed_spend && values.actual_committed_spend.value ? (
       formatCurrency(Number(values.actual_committed_spend.value), values.actual_committed_spend.units || 'USD')
     ) : (
       <EmptyValueState />
     );
-  const excessActualSpend: string | React.ReactNode =
-    values && values.excess_committed_spend && values.excess_committed_spend.value ? (
-      formatCurrency(Number(values.excess_committed_spend.value), values.excess_committed_spend.units || 'USD')
-    ) : (
-      <EmptyValueState />
-    );
+
+  // Don't show excess spend unless greater than zero
+  const excessSpend = values && values.excess_committed_spend ? Number(values.excess_committed_spend.value) : undefined;
+  const excessActualSpend: string =
+    excessSpend > 0 ? formatCurrency(excessSpend, values.excess_committed_spend.units || 'USD') : undefined;
+
   const percent = values && values.delta && values.delta.percent ? Number(values.delta.percent) : undefined;
   const percentage: string | React.ReactNode = percent !== undefined ? formatPercentage(percent) : <EmptyValueState />;
 

--- a/src/routes/overview/components/excess-actual-spend/ExcessActualSpend.tsx
+++ b/src/routes/overview/components/excess-actual-spend/ExcessActualSpend.tsx
@@ -19,6 +19,9 @@ const ExcessActualSpend: React.FC<ExcessActualSpendProps> = ({
   excessActualSpendBreakdown,
   intl,
 }) => {
+  if (!excessActualSpend && !excessActualSpendBreakdown) {
+    return null;
+  }
   const showExcessActualSpendBreakdown = excessActualSpendBreakdown && !excessActualSpend;
   return (
     <span style={styles.infoIcon}>


### PR DESCRIPTION
Modified the "Excess actual spend included" popover so that it's not shown when excess spend is zero