### PR TITLE
Adjust dates to use contract-line

### DIFF
--- a/src/routes/components/page-heading/PageHeading.tsx
+++ b/src/routes/components/page-heading/PageHeading.tsx
@@ -47,10 +47,10 @@ const PageHeading: React.FC<PageHeadingProps> = ({ children, intl }) => {
 
   const accountName: string | React.ReactNode = values && values.account_name ? values.account_name : emptyValue;
   const accountNumber: string | React.ReactNode = values && values.account_number ? values.account_number : emptyValue;
-  const contractStartDate =
-    values && values.contract_start_date ? new Date(values.contract_start_date + 'T00:00:00') : undefined;
-  const contractEndDate =
-    values && values.contract_end_date ? new Date(values.contract_end_date + 'T00:00:00') : undefined;
+  const contractLineStartDate =
+    values && values.contract_line_start_date ? new Date(values.contract_line_start_date + 'T00:00:00') : undefined;
+  const contractLineEndDate =
+    values && values.contract_line_end_date ? new Date(values.contract_line_end_date + 'T00:00:00') : undefined;
   const consumptionDate =
     values && values.consumption_date ? new Date(values.consumption_date + 'T00:00:00') : undefined;
 
@@ -79,8 +79,8 @@ const PageHeading: React.FC<PageHeadingProps> = ({ children, intl }) => {
             <div style={styles.headingContentRight}>
               {intl.formatMessage(messages.contractDate, {
                 dateRange:
-                  contractStartDate && contractEndDate
-                    ? intl.formatDateTimeRange(contractStartDate, contractEndDate, {
+                  contractLineStartDate && contractLineEndDate
+                    ? intl.formatDateTimeRange(contractLineStartDate, contractLineEndDate, {
                         month: 'long',
                         year: 'numeric',
                       })

--- a/src/routes/details/Details.tsx
+++ b/src/routes/details/Details.tsx
@@ -41,8 +41,8 @@ interface DetailsOwnProps {
 }
 
 interface DetailsStateProps {
+  consumptionDate?: Date;
   contractLineStartDate?: Date;
-  contractStartDate?: Date;
   endDate?: Date;
   query?: Query;
   report?: Report;
@@ -64,8 +64,8 @@ const Details: React.FC<DetailsProps> = ({ intl }) => {
   const [sourceOfSpend, setSourceOfSpend] = useStateCallback(useDefaultSourceOfSpend());
 
   const {
+    consumptionDate,
     contractLineStartDate,
-    contractStartDate,
     endDate,
     query,
     report,
@@ -270,8 +270,8 @@ const Details: React.FC<DetailsProps> = ({ intl }) => {
     <React.Fragment>
       <PageHeading>
         <DetailsHeaderToolbar
+          consumptionDate={consumptionDate}
           contractLineStartDate={contractLineStartDate}
-          contractStartDate={contractStartDate}
           dateRange={dateRange}
           endDate={endDate}
           groupBy={groupBy}
@@ -338,8 +338,6 @@ const useDefaultSourceOfSpend = () => {
 const useMapToProps = ({ dateRange, groupBy, sourceOfSpend }: DetailsOwnProps): DetailsStateProps => {
   const { summary } = useAccountSummaryMapToProps();
   const values = summary && summary.data && summary.data.length && summary.data[0];
-  const contractStartDate =
-    values && values.contract_start_date ? new Date(values.contract_start_date + 'T00:00:00') : undefined;
   const contractLineStartDate =
     values && values.contract_line_start_date ? new Date(values.contract_line_start_date + 'T00:00:00') : undefined;
   const consumptionDate =
@@ -347,16 +345,16 @@ const useMapToProps = ({ dateRange, groupBy, sourceOfSpend }: DetailsOwnProps): 
 
   const { endDate, query, report, reportError, reportFetchStatus, reportQueryString, startDate } =
     useDetailsMapDateRangeToProps({
-      contractStartDate,
       consumptionDate,
+      contractLineStartDate,
       dateRange,
       groupBy,
       sourceOfSpend,
     });
 
   return {
+    consumptionDate,
     contractLineStartDate,
-    contractStartDate,
     endDate,
     query,
     report,

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -20,8 +20,8 @@ import { optionActions, optionSelectors } from 'store/options';
 import { GroupByType, SourceOfSpendType } from './types';
 
 interface DetailsHeaderToolbarOwnProps {
+  consumptionDate?: Date;
   contractLineStartDate?: Date;
-  contractStartDate?: Date;
   dateRange?: string;
   endDate?: Date;
   groupBy?: string;
@@ -58,8 +58,8 @@ const sourceOfSpendOptions: PerspectiveOption[] = [
 ];
 
 const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
+  consumptionDate = new Date(),
   contractLineStartDate = new Date(),
-  contractStartDate = new Date(),
   dateRange,
   groupBy,
   intl,
@@ -73,6 +73,9 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
   const { options } = useMapToProps();
 
   const formatDateRange = (startDate, endDate) => {
+    if (startDate === undefined || endDate === undefined) {
+      return undefined;
+    }
     return intl.formatDateTimeRange(startDate, endDate, {
       month: 'long',
       year: 'numeric',
@@ -80,32 +83,51 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
   };
 
   const isContractedLastYearDateRangeDisabled = () => {
-    const { startDate } = getDateRange(DateRangeType.contractedLastYear, contractLineStartDate);
-    return startDate < contractStartDate;
+    const { startDate } = getDateRange({
+      dateRange: DateRangeType.contractedLastYear,
+      contractLineStartDate,
+    });
+    return startDate < contractLineStartDate;
   };
 
-  const getContractedLastYearDateRangeDesc = () => {
-    const { endDate, startDate } = getDateRange(DateRangeType.contractedLastYear, contractLineStartDate);
+  const getContractedLastYearDateRange = () => {
+    const { endDate, startDate } = getDateRange({
+      dateRange: DateRangeType.contractedLastYear,
+      contractLineStartDate,
+    });
     return formatDateRange(startDate, endDate);
   };
 
   const getContractedYtdDateRange = () => {
-    const { endDate, startDate } = getDateRange(DateRangeType.contractedYtd, contractLineStartDate);
+    const { endDate, startDate } = getDateRange({
+      dateRange: DateRangeType.contractedYtd,
+      consumptionDate,
+      contractLineStartDate,
+    });
     return formatDateRange(startDate, endDate);
   };
 
   const getLastNineMonthsDateRange = () => {
-    const { endDate, startDate } = getDateRange(DateRangeType.lastNineMonths);
+    const { endDate, startDate } = getDateRange({
+      dateRange: DateRangeType.lastNineMonths,
+      consumptionDate,
+    });
     return formatDateRange(startDate, endDate);
   };
 
   const getLastSixMonthsDateRange = () => {
-    const { endDate, startDate } = getDateRange(DateRangeType.lastSixMonths);
+    const { endDate, startDate } = getDateRange({
+      dateRange: DateRangeType.lastSixMonths,
+      consumptionDate,
+    });
     return formatDateRange(startDate, endDate);
   };
 
   const getLastThreeMonthsDateRange = () => {
-    const { endDate, startDate } = getDateRange(DateRangeType.lastThreeMonths);
+    const { endDate, startDate } = getDateRange({
+      dateRange: DateRangeType.lastThreeMonths,
+      consumptionDate,
+    });
     return formatDateRange(startDate, endDate);
   };
 
@@ -115,7 +137,7 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
     newOptions.map(option => {
       switch (option.value) {
         case DateRangeType.contractedLastYear:
-          option.description = getContractedLastYearDateRangeDesc();
+          option.description = getContractedLastYearDateRange();
           option.isDisabled = isContractedLastYearDateRangeDisabled();
           break;
         case DateRangeType.contractedYtd:
@@ -266,7 +288,7 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
         currentItem={dateRange}
         id="dateRange"
         label={intl.formatMessage(messages.dateRangeLabel)}
-        minWidth={200}
+        minWidth={225}
         onSelected={handleOnDateRangeSelected}
         options={getDateRangeOptions()}
       />

--- a/src/routes/details/utils.ts
+++ b/src/routes/details/utils.ts
@@ -25,8 +25,8 @@ interface AccountSummaryStateProps {
 }
 
 interface DetailsOwnProps {
-  contractStartDate?: Date;
   consumptionDate?: Date;
+  contractLineStartDate?: Date;
   dateRange?: string;
   endDate?: Date;
   groupBy?: string;
@@ -97,15 +97,19 @@ export const useAccountSummaryMapToProps = (deps = []): AccountSummaryStateProps
 };
 
 export const useDetailsMapDateRangeToProps = ({
-  contractStartDate,
   consumptionDate,
+  contractLineStartDate,
   dateRange,
   groupBy,
   groupByValue,
   secondaryGroupBy,
   sourceOfSpend,
 }: DetailsOwnProps): DetailsStateProps => {
-  const { endDate, startDate } = getDateRange(dateRange, contractStartDate, consumptionDate);
+  const { endDate, startDate } = getDateRange({
+    dateRange,
+    consumptionDate,
+    contractLineStartDate,
+  });
 
   return useDetailsMapToProps({
     dateRange,
@@ -156,7 +160,7 @@ export const useDetailsMapToProps = ({
       ...(sourceOfSpend !== SourceOfSpendType.all && { source_of_spend: getSourceOfSpendFilter(sourceOfSpend) }),
       ...(secondaryGroupBy && { limit: undefined, offset: 0 }), // Children are not paginated
     },
-    ...formatDate(startDate, endDate),
+    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
     sourceOfSpend: undefined,
     dateRange: undefined,
   });
@@ -172,7 +176,7 @@ export const useDetailsMapToProps = ({
   );
 
   useEffect(() => {
-    if (!reportError && reportFetchStatus !== FetchStatus.inProgress && startDate) {
+    if (!reportError && reportFetchStatus !== FetchStatus.inProgress && startDate && endDate) {
       if (secondaryGroupBy) {
         if (secondaryGroupBy !== GroupByType.none && isExpanded) {
           dispatch(reportActions.fetchReport(reportPathsType, reportType, reportQueryString));

--- a/src/routes/utils/dateRange.ts
+++ b/src/routes/utils/dateRange.ts
@@ -16,33 +16,31 @@ export const enum DateRangeType {
   lastThreeMonths = 'last_three_months', // Last 30 days (Dec 18 - Jan 17)
 }
 
-export const getDateRange = (
-  dateRangeType: string,
-  contractStartDate: Date = undefined,
-  consumptionDate: Date = undefined,
-  isFormatted = false
-) => {
-  let dateRange;
+interface DateRangeProps {
+  dateRange: string;
+  consumptionDate?: Date;
+  contractLineStartDate?: Date;
+  isFormatted?: boolean;
+}
 
-  switch (dateRangeType) {
+export const getDateRange = ({
+  dateRange,
+  consumptionDate,
+  contractLineStartDate,
+  isFormatted = false,
+}: DateRangeProps) => {
+  switch (dateRange) {
     case DateRangeType.contractedLastYear:
-      dateRange = getContractedLastYear(contractStartDate, isFormatted);
-      break;
+      return getContractedLastYear(contractLineStartDate, isFormatted);
     case DateRangeType.contractedYtd:
-      dateRange = getContractedYtd(contractStartDate, consumptionDate, isFormatted);
-      break;
+      return getContractedYtd(contractLineStartDate, consumptionDate, isFormatted);
     case DateRangeType.lastNineMonths:
-      dateRange = getLastNineMonthsDate(consumptionDate, isFormatted);
-      break;
+      return getLastNineMonthsDate(consumptionDate, isFormatted);
     case DateRangeType.lastSixMonths:
-      dateRange = getLastSixMonthsDate(consumptionDate, isFormatted);
-      break;
+      return getLastSixMonthsDate(consumptionDate, isFormatted);
     case DateRangeType.lastThreeMonths:
-      dateRange = getLastThreeMonthsDate(consumptionDate, isFormatted);
-      break;
+      return getLastThreeMonthsDate(consumptionDate, isFormatted);
     default:
-      dateRange = undefined;
-      break;
+      return undefined;
   }
-  return dateRange;
 };

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -52,29 +52,35 @@ export const formatDate = (startDate, endDate, isFormatted = true) => {
       };
 };
 
-export const getContractedLastYear = (startDate: Date = new Date(), isFormatted) => {
-  const endDate = new Date(startDate.getTime());
+export const getContractedLastYear = (contractLineStartDate: Date = new Date(), isFormatted) => {
+  if (contractLineStartDate === undefined) {
+    return { startDate: undefined, endDate: undefined };
+  }
+  const endDate = new Date(contractLineStartDate.getTime());
   endDate.setDate(1); // Workaround to compare month properly
-  endDate.setMonth(endDate.getMonth() - 1);
+  // endDate.setMonth(endDate.getMonth() - 1); // Todo: do we include month of contractLineStartDate?
 
-  const _startDate = new Date(startDate.getTime());
-  _startDate.setFullYear(_startDate.getFullYear() - 1);
+  const startDate = new Date(contractLineStartDate.getTime());
+  startDate.setFullYear(startDate.getFullYear() - 1);
 
-  return formatDate(_startDate, endDate, isFormatted);
+  return formatDate(startDate, endDate, isFormatted);
 };
 
-export const getContractedYtd = (startDate, consumptionDate, isFormatted) => {
-  const endDate = consumptionDate ? consumptionDate : new Date();
-  const _startDate = startDate ? new Date(startDate.getTime()) : new Date();
+export const getContractedYtd = (contractLineStartDate, consumptionDate, isFormatted) => {
+  if (contractLineStartDate === undefined || consumptionDate === undefined) {
+    return { startDate: undefined, endDate: undefined };
+  }
+  const endDate = consumptionDate;
+  const startDate = new Date(contractLineStartDate.getTime());
 
   // Workaround to compare month properly
   endDate.setDate(1);
-  _startDate.setDate(1);
+  startDate.setDate(1);
 
   if (!consumptionDate) {
     endDate.setMonth(endDate.getMonth() - 1);
   }
-  return formatDate(_startDate, endDate, isFormatted);
+  return formatDate(startDate, endDate, isFormatted);
 };
 
 // Returns 9 months, including today's date
@@ -94,7 +100,10 @@ export const getLastThreeMonthsDate = (consumptionDate, isFormatted) => {
 
 // Returns today's month - offset
 export const getLastMonthsDate = (consumptionDate: Date, offset: number, isFormatted) => {
-  const endDate = consumptionDate ? consumptionDate : getDate();
+  if (consumptionDate === undefined) {
+    return { startDate: undefined, endDate: undefined };
+  }
+  const endDate = consumptionDate;
   const startDate = new Date();
 
   // Workaround to compare month properly


### PR DESCRIPTION
- Page heading should show contract line dates
- Date range options should use contract line and consumption dates