### PR TITLE
Disable table actions for no data

### DIFF
--- a/src/routes/components/data-toolbar/DataToolbar.tsx
+++ b/src/routes/components/data-toolbar/DataToolbar.tsx
@@ -123,6 +123,10 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
     return chips;
   };
 
+  const hasFilters = () => {
+    return Object.keys(filters).length > 0 ? true : false;
+  };
+
   const onDelete = (type: any, chip: any) => {
     // Todo: workaround for https://github.com/patternfly/patternfly-react/issues/3552
     // This prevents us from using a localized string, if necessary
@@ -147,6 +151,8 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
 
   // Category input
   const getCategoryInput = (categoryOption: ToolbarChipGroup) => {
+    const disabled = isDisabled && !hasFilters();
+
     return (
       <ToolbarFilter
         categoryName={categoryOption}
@@ -162,7 +168,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
               category={currentCategory}
               filterPathsType={filterPathsType}
               filterType={categoryOption.key as FilterType}
-              isDisabled={isDisabled}
+              isDisabled={disabled}
               onSelect={value => onCategoryInputSelect(value, categoryOption.key)}
               placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: categoryOption.key })}
             />
@@ -172,7 +178,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
                 aria-label={intl.formatMessage(messages.filterByInputAriaLabel, { value: categoryOption.key })}
                 name={`category-input-${categoryOption.key}`}
                 id={`category-input-${categoryOption.key}`}
-                isDisabled={isDisabled}
+                isDisabled={disabled}
                 onChange={handleOnCategoryInputChange}
                 onKeyDown={evt => onCategoryInput(evt, categoryOption.key)}
                 placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: categoryOption.key })}
@@ -180,7 +186,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
                 value={categoryInput}
               />
               <Button
-                isDisabled={isDisabled}
+                isDisabled={disabled}
                 variant={ButtonVariant.control}
                 aria-label={intl.formatMessage(messages.filterByButtonAriaLabel, { value: categoryOption.key })}
                 onClick={evt => onCategoryInput(evt, categoryOption.key)}

--- a/src/routes/details/DetailsFilterToolbar.tsx
+++ b/src/routes/details/DetailsFilterToolbar.tsx
@@ -10,6 +10,7 @@ import type { Filter } from 'routes/utils/filter';
 
 interface DetailsFilterToolbarOwnProps {
   groupBy: string; // Options for category menu
+  isDisabled?: boolean;
   isExportDisabled?: boolean; // Sync category selection with groupBy value
   onExportClicked();
   onFilterAdded(filter: Filter);
@@ -23,6 +24,7 @@ type DetailsFilterToolbarProps = DetailsFilterToolbarOwnProps & WrappedComponent
 const DetailsFilterToolbarBase: React.FC<DetailsFilterToolbarProps> = ({
   groupBy,
   intl,
+  isDisabled,
   isExportDisabled,
   onExportClicked,
   onFilterAdded,
@@ -43,6 +45,7 @@ const DetailsFilterToolbarBase: React.FC<DetailsFilterToolbarProps> = ({
       categoryOptions={getCategoryOptions()}
       filterPathsType={FilterPathsType.detailsFilter}
       groupBy={groupBy}
+      isDisabled={isDisabled}
       isExportDisabled={isExportDisabled}
       onExportClicked={onExportClicked}
       onFilterAdded={onFilterAdded}


### PR DESCRIPTION
There are scenarios when table actions should be disabled. Including the filter, export, and pagination.

1. While the page is loading, all table actions are disabled
2. If the API returns no data, all table actions are disabled
3. If there is no data due to filtering, only the filter actions remain enabled
