### PR TITLE
Integrate committedSpendTrendChart API

### DIFF
--- a/src/api/reports/accountSummaryReport.test.ts
+++ b/src/api/reports/accountSummaryReport.test.ts
@@ -5,6 +5,6 @@ import { ReportType } from './report';
 
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
-  runReport(ReportType.billing, query);
+  runReport(ReportType.details, query);
   expect(axios.get).toBeCalledWith(`reports/hcsSummary?${query}`);
 });

--- a/src/api/reports/accountSummaryReport.ts
+++ b/src/api/reports/accountSummaryReport.ts
@@ -28,7 +28,7 @@ export interface AccountSummaryReport extends Report {
 }
 
 export const ReportTypePaths: Partial<Record<ReportType, string>> = {
-  [ReportType.billing]: 'reports/hcsSummary',
+  [ReportType.details]: 'reports/hcsSummary',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/detailsReport.test.ts
+++ b/src/api/reports/detailsReport.test.ts
@@ -5,6 +5,6 @@ import { ReportType } from './report';
 
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
-  runReport(ReportType.billing, query);
+  runReport(ReportType.details, query);
   expect(axios.get).toBeCalledWith(`reports/details?${query}`);
 });

--- a/src/api/reports/detailsReport.ts
+++ b/src/api/reports/detailsReport.ts
@@ -17,7 +17,8 @@ export interface DetailsFilterReport extends Report {
 }
 
 export const ReportTypePaths: Partial<Record<ReportType, string>> = {
-  [ReportType.billing]: 'reports/details',
+  [ReportType.details]: 'reports/details',
+  [ReportType.committedSpend]: 'reports/committedSpendTrendChart',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/report.ts
+++ b/src/api/reports/report.ts
@@ -19,6 +19,8 @@ export interface ReportData {
 }
 
 export interface ReportMeta extends PagedMetaData {
+  excessAmountSpend: number; // Todo: replace with ReportValue
+  // excessAmountSpend: ReportValue;
   count?: string | number;
   delta?: {
     percent: number;
@@ -40,7 +42,8 @@ export interface Report extends PagedResponse<ReportData, ReportMeta> {}
 
 // eslint-disable-next-line no-shadow
 export const enum ReportType {
-  billing = 'billing',
+  committedSpend = 'committedSpend',
+  details = 'details',
 }
 
 // eslint-disable-next-line no-shadow

--- a/src/routes/components/charts/common/chart-datum.ts
+++ b/src/routes/components/charts/common/chart-datum.ts
@@ -249,7 +249,7 @@ export function padChartDatums({
         createReportDatum({
           computedItem: { date, id: date },
           reportItemValue: null, // Todo: This is only used with the fake data -- remove after APIs are avialable
-          value: padWithPrevious ? prevChartDatum.y : null,
+          value: padWithPrevious && prevChartDatum ? prevChartDatum.y : null,
         })
       );
     }

--- a/src/routes/components/charts/common/chart-datum.ts
+++ b/src/routes/components/charts/common/chart-datum.ts
@@ -29,6 +29,7 @@ export interface TransformData {
   report: Report;
   startDate?: Date;
   endDate?: Date;
+  padWithPrevious?: boolean; // Used with committed spend threshold
   shiftDateByYear?: number; // Shift the year, so we can overlap current and previous months
   reportItem?: string;
   reportItemValue?: string; // useful for infrastructure.usage values
@@ -47,6 +48,7 @@ export interface ReportData<T extends ComputedReportItem> {
 export interface PadData {
   datums: ChartDatum[];
   endDate?: Date;
+  padWithPrevious?: boolean;
   startDate?: Date;
 }
 
@@ -161,6 +163,7 @@ export function transformReport({
   report,
   startDate,
   endDate,
+  padWithPrevious,
   shiftDateByYear = 0, // Shift the year, so we can overlap current and previous months
   reportItem = 'actualSpend',
 }: TransformData): ChartDatum[] {
@@ -186,7 +189,7 @@ export function transformReport({
       return createReportDatum({ value, computedItem, shiftDateByYear, reportItem });
     });
   }
-  return padChartDatums({ datums, startDate, endDate });
+  return padChartDatums({ datums, startDate, endDate, padWithPrevious });
 }
 
 export function createReportDatum<T extends ComputedReportItem>({
@@ -225,11 +228,17 @@ export function createReportDatum<T extends ComputedReportItem>({
 // This pads chart datums with null datum objects, representing missing data at the beginning and end of the
 // data series. The remaining data is left as is to allow for extrapolation. This allows us to display a "no data"
 // message in the tooltip, which helps distinguish between zero values and when there is no data available.
-export function padChartDatums({ datums, startDate = getYear(1), endDate = getToday() }: PadData): ChartDatum[] {
+export function padChartDatums({
+  datums,
+  startDate = getYear(1),
+  endDate = getToday(),
+  padWithPrevious,
+}: PadData): ChartDatum[] {
   const result = [];
   if (!datums || datums.length === 0) {
     return result;
   }
+  let prevChartDatum;
   for (const padDate = new Date(startDate.getTime()); padDate < endDate; padDate.setMonth(padDate.getMonth() + 1)) {
     const date = format(padDate, 'yyyy-MM');
     const chartDatum = datums.find(val => val.key === date);
@@ -239,11 +248,12 @@ export function padChartDatums({ datums, startDate = getYear(1), endDate = getTo
       result.push(
         createReportDatum({
           computedItem: { date, id: date },
-          reportItemValue: null,
-          value: null,
+          reportItemValue: null, // Todo: This is only used with the fake data -- remove after APIs are avialable
+          value: padWithPrevious ? prevChartDatum.y : null,
         })
       );
     }
+    prevChartDatum = chartDatum;
   }
   return result;
 }

--- a/src/routes/components/export/ExportSubmit.tsx
+++ b/src/routes/components/export/ExportSubmit.tsx
@@ -40,7 +40,7 @@ interface ExportSubmitStateProps {
 
 type ExportSubmitProps = ExportSubmitOwnProps & WrappedComponentProps;
 
-const reportType = ReportType.billing;
+const reportType = ReportType.details;
 
 const ExportSubmitBase: React.FC<ExportSubmitProps> = ({
   disabled,

--- a/src/routes/components/page-heading/PageHeading.tsx
+++ b/src/routes/components/page-heading/PageHeading.tsx
@@ -115,7 +115,7 @@ const useMapToProps = (): PageHeadingStateProps => {
 
   const reportQueryString = getQuery(query);
   const reportPathsType = ReportPathsType.accountSummary;
-  const reportType = ReportType.billing;
+  const reportType = ReportType.details;
   const report = useSelector((state: RootState) =>
     reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString)
   );

--- a/src/routes/details/Details.tsx
+++ b/src/routes/details/Details.tsx
@@ -43,6 +43,7 @@ interface DetailsOwnProps {
 interface DetailsStateProps {
   consumptionDate?: Date;
   contractLineStartDate?: Date;
+  contractStartDate?: Date;
   endDate?: Date;
   query?: Query;
   report?: Report;
@@ -66,6 +67,7 @@ const Details: React.FC<DetailsProps> = ({ intl }) => {
   const {
     consumptionDate,
     contractLineStartDate,
+    contractStartDate,
     endDate,
     query,
     report,
@@ -284,6 +286,7 @@ const Details: React.FC<DetailsProps> = ({ intl }) => {
         <DetailsHeaderToolbar
           consumptionDate={consumptionDate}
           contractLineStartDate={contractLineStartDate}
+          contractStartDate={contractStartDate}
           dateRange={dateRange}
           endDate={endDate}
           groupBy={groupBy}
@@ -370,6 +373,7 @@ const useMapToProps = ({ dateRange, groupBy, sourceOfSpend }: DetailsOwnProps): 
   return {
     consumptionDate,
     contractLineStartDate,
+    contractStartDate,
     endDate,
     query,
     report,

--- a/src/routes/details/Details.tsx
+++ b/src/routes/details/Details.tsx
@@ -353,12 +353,12 @@ const useQueryFromRoute = () => {
 const useMapToProps = ({ dateRange, groupBy, sourceOfSpend }: DetailsOwnProps): DetailsStateProps => {
   const { summary } = useAccountSummaryMapToProps();
   const values = summary && summary.data && summary.data.length && summary.data[0];
+  const consumptionDate =
+    values && values.consumption_date ? new Date(values.consumption_date + 'T00:00:00') : undefined;
   const contractLineStartDate =
     values && values.contract_line_start_date ? new Date(values.contract_line_start_date + 'T00:00:00') : undefined;
   const contractStartDate =
     values && values.contract_start_date ? new Date(values.contract_start_date + 'T00:00:00') : undefined;
-  const consumptionDate =
-    values && values.consumption_date ? new Date(values.consumption_date + 'T00:00:00') : undefined;
 
   const { endDate, query, report, reportError, reportFetchStatus, reportQueryString, startDate } =
     useDetailsMapDateRangeToProps({

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -21,6 +21,7 @@ import { optionActions, optionSelectors } from 'store/options';
 interface DetailsHeaderToolbarOwnProps {
   consumptionDate?: Date;
   contractLineStartDate?: Date;
+  contractStartDate?: Date;
   dateRange?: string;
   endDate?: Date;
   groupBy?: string;
@@ -57,8 +58,9 @@ const sourceOfSpendOptions: PerspectiveOption[] = [
 ];
 
 const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
-  consumptionDate = new Date(),
-  contractLineStartDate = new Date(),
+  consumptionDate,
+  contractLineStartDate,
+  contractStartDate,
   dateRange,
   groupBy,
   intl,
@@ -86,7 +88,7 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
       dateRange: DateRangeType.contractedLastYear,
       contractLineStartDate,
     });
-    return startDate < contractLineStartDate;
+    return startDate < contractStartDate;
   };
 
   const getContractedLastYearDateRange = () => {

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -17,6 +17,7 @@ import { DateRangeType, getDateRange } from 'routes/utils/dateRange';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { optionActions, optionSelectors } from 'store/options';
+import { isContractedLastYearValid } from 'utils/dates';
 
 interface DetailsHeaderToolbarOwnProps {
   consumptionDate?: Date;
@@ -83,14 +84,6 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
     });
   };
 
-  const isContractedLastYearDateRangeDisabled = () => {
-    const { startDate } = getDateRange({
-      dateRange: DateRangeType.contractedLastYear,
-      contractLineStartDate,
-    });
-    return startDate < contractStartDate;
-  };
-
   const getContractedLastYearDateRange = () => {
     const { endDate, startDate } = getDateRange({
       dateRange: DateRangeType.contractedLastYear,
@@ -139,7 +132,7 @@ const DetailsHeaderToolbarBase: React.FC<DetailsToolbarProps> = ({
       switch (option.value) {
         case DateRangeType.contractedLastYear:
           option.description = getContractedLastYearDateRange();
-          option.isDisabled = isContractedLastYearDateRangeDisabled();
+          option.isDisabled = isContractedLastYearValid(contractLineStartDate, contractStartDate);
           break;
         case DateRangeType.contractedYtd:
           option.description = getContractedYtdDateRange();

--- a/src/routes/details/DetailsTable.tsx
+++ b/src/routes/details/DetailsTable.tsx
@@ -124,7 +124,7 @@ const DetailsTableBase: React.FC<DetailsTableProps> = ({
         name: intl.formatDate(currentDate, { month: 'long' }),
         date: mapId,
         isSortable,
-        orderBy: 'actual_spend',
+        orderBy: groupBy,
       });
     }
 

--- a/src/routes/details/utils.ts
+++ b/src/routes/details/utils.ts
@@ -73,7 +73,7 @@ export const useAccountSummaryMapToProps = (deps = []): AccountSummaryStateProps
   const summaryQueryString = getQuery(query);
 
   const reportPathsType = ReportPathsType.accountSummary;
-  const reportType = ReportType.billing;
+  const reportType = ReportType.details;
 
   const summary: AccountSummaryReport = useSelector((state: RootState) =>
     reportSelectors.selectReport(state, reportPathsType, reportType, summaryQueryString)
@@ -138,7 +138,7 @@ export const useDetailsMapToProps = ({
   groupByValue,
   isExpanded = false,
   reportPathsType = ReportPathsType.details,
-  reportType = ReportType.billing,
+  reportType = ReportType.details,
   secondaryGroupBy,
   sourceOfSpend = SourceOfSpendType.all,
   startDate,

--- a/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdown.tsx
+++ b/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdown.tsx
@@ -88,8 +88,9 @@ const ActualSpendBreakdownBase: React.FC<ActualSpendBreakdownProps> = ({ intl, w
   return (
     <ReportSummary
       detailsLink={getDetailsLink()}
-      excessActualSpendBreakdown={formatCurrency(98321.34, 'USD')}
+      excessActualSpend={formatCurrency(98321.34, 'USD')}
       fetchStatus={reportFetchStatus}
+      showBreakdown
       title={widget.title}
     >
       <Perspective currentItem={perspective} onSelected={handleOnPerspectiveSelected} options={perspectiveOptions} />

--- a/src/routes/overview/components/actual-spend/ActualSpend.tsx
+++ b/src/routes/overview/components/actual-spend/ActualSpend.tsx
@@ -51,8 +51,9 @@ const ActualSpend: React.FC<ActualSpendProps> = ({ intl, widgetId }) => {
 
   // Don't show excess spend unless greater than zero
   const excessSpend = values && values.excess_committed_spend ? Number(values.excess_committed_spend.value) : undefined;
-  const excessActualSpend: string =
-    excessSpend > 0 ? formatCurrency(excessSpend, values.excess_committed_spend.units || 'USD') : undefined;
+  const excessActualSpend: string = excessSpend
+    ? formatCurrency(excessSpend, values.excess_committed_spend.units || 'USD')
+    : undefined;
 
   const percent = values && values.delta && values.delta.percent ? Number(values.delta.percent) : undefined;
   const percentage: string | React.ReactNode = percent !== undefined ? formatPercentage(percent) : <EmptyValueState />;

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendTransform.tsx
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendTransform.tsx
@@ -32,13 +32,25 @@ const CommittedSpendTrendTransformBase: React.FC<CommittedSpendTrendTransformPro
 }) => {
   const getData = () => {
     const current = currentReport
-      ? transformReport({ report: currentReport, reportItem: 'actualSpend', startDate, endDate })
+      ? transformReport({ endDate, report: currentReport, reportItem: 'actualSpend', startDate })
       : undefined;
-    const previous = currentReport
-      ? transformReport({ report: previousReport, reportItem: 'actualSpend', startDate, endDate })
+    const previous = previousReport
+      ? transformReport({
+          endDate,
+          report: previousReport,
+          reportItem: 'actualSpend',
+          shiftDateByYear: 1,
+          startDate,
+        })
       : undefined;
     const threshold = thresholdReport
-      ? transformReport({ report: thresholdReport, reportItem: 'committedSpend', startDate, endDate })
+      ? transformReport({
+          endDate,
+          padWithPrevious: true,
+          report: thresholdReport,
+          reportItem: 'committedSpend',
+          startDate,
+        })
       : undefined;
 
     return { current, previous, threshold } as any;

--- a/src/routes/overview/components/committed-spend-trend/utils.ts
+++ b/src/routes/overview/components/committed-spend-trend/utils.ts
@@ -43,12 +43,6 @@ interface DetailsStateProps {
   startDate?: Date;
 }
 
-export const baseQuery: Query = {
-  filter: {
-    limit: 100,
-  },
-};
-
 export const useAccountSummaryMapToProps = (deps = []): AccountSummaryStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
 
@@ -58,7 +52,7 @@ export const useAccountSummaryMapToProps = (deps = []): AccountSummaryStateProps
   const summaryQueryString = getQuery(query);
 
   const reportPathsType = ReportPathsType.accountSummary;
-  const reportType = ReportType.billing;
+  const reportType = ReportType.details;
 
   const summary: AccountSummaryReport = useSelector((state: RootState) =>
     reportSelectors.selectReport(state, reportPathsType, reportType, summaryQueryString)
@@ -113,14 +107,14 @@ export const useDetailsMapToProps = ({
   endDate,
   isExpanded = false,
   reportPathsType = ReportPathsType.details,
-  reportType = ReportType.billing,
+  reportType = ReportType.committedSpend,
   startDate,
 }: DetailsOwnProps): DetailsStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
 
   const query = {
     filter: {
-      ...baseQuery.filter, // Todo do we need to set limit?
+      resolution: 'cumulative',
     },
     dateRange,
   };

--- a/src/routes/overview/components/committed-spend-trend/utils.ts
+++ b/src/routes/overview/components/committed-spend-trend/utils.ts
@@ -105,7 +105,6 @@ export const useDetailsMapDateRangeToProps = ({
 export const useDetailsMapToProps = ({
   dateRange,
   endDate,
-  isExpanded = false,
   reportPathsType = ReportPathsType.details,
   reportType = ReportType.committedSpend,
   startDate,
@@ -139,7 +138,7 @@ export const useDetailsMapToProps = ({
     if (!reportError && reportFetchStatus !== FetchStatus.inProgress && startDate && endDate) {
       dispatch(reportActions.fetchReport(reportPathsType, reportType, reportQueryString));
     }
-  }, [reportQueryString, isExpanded]);
+  }, [endDate, reportQueryString, startDate]);
 
   return {
     endDate,

--- a/src/routes/overview/components/excess-actual-spend/ExcessActualSpend.tsx
+++ b/src/routes/overview/components/excess-actual-spend/ExcessActualSpend.tsx
@@ -9,20 +9,15 @@ import { styles } from './ExcessActualSpend.styles';
 
 interface ExcessActualSpendOwnProps {
   excessActualSpend?: string | React.ReactNode;
-  excessActualSpendBreakdown?: string | React.ReactNode;
+  showBreakdown?: boolean;
 }
 
 type ExcessActualSpendProps = ExcessActualSpendOwnProps & WrappedComponentProps;
 
-const ExcessActualSpend: React.FC<ExcessActualSpendProps> = ({
-  excessActualSpend,
-  excessActualSpendBreakdown,
-  intl,
-}) => {
-  if (!excessActualSpend && !excessActualSpendBreakdown) {
+const ExcessActualSpend: React.FC<ExcessActualSpendProps> = ({ excessActualSpend, intl, showBreakdown }) => {
+  if (!excessActualSpend) {
     return null;
   }
-  const showExcessActualSpendBreakdown = excessActualSpendBreakdown && !excessActualSpend;
   return (
     <span style={styles.infoIcon}>
       <Popover
@@ -32,23 +27,18 @@ const ExcessActualSpend: React.FC<ExcessActualSpendProps> = ({
           <>
             <p style={styles.infoTitle}>
               {intl.formatMessage(
-                showExcessActualSpendBreakdown ? messages.excessActualSpendExcluded : messages.excessActualSpendIncluded
+                showBreakdown ? messages.excessActualSpendExcluded : messages.excessActualSpendIncluded
               )}
             </p>
             <br />
-            {showExcessActualSpendBreakdown ? (
-              <p>
-                {intl.formatMessage(messages.excessActualSpendBreakdownDesc, {
-                  value: <b>{excessActualSpendBreakdown}</b>,
-                })}
-              </p>
-            ) : (
-              <p>
-                {intl.formatMessage(messages.excessActualSpendDesc, {
+            <p>
+              {intl.formatMessage(
+                showBreakdown ? messages.excessActualSpendBreakdownDesc : messages.excessActualSpendDesc,
+                {
                   value: <b>{excessActualSpend}</b>,
-                })}
-              </p>
-            )}
+                }
+              )}
+            </p>
           </>
         }
       >
@@ -60,7 +50,7 @@ const ExcessActualSpend: React.FC<ExcessActualSpendProps> = ({
             <InfoCircleIcon />
             <span style={styles.infoLabel}>
               {intl.formatMessage(
-                showExcessActualSpendBreakdown ? messages.excessActualSpendExcluded : messages.excessActualSpendIncluded
+                showBreakdown ? messages.excessActualSpendExcluded : messages.excessActualSpendIncluded
               )}
             </span>
           </span>

--- a/src/routes/overview/components/report-summary/ReportSummary.tsx
+++ b/src/routes/overview/components/report-summary/ReportSummary.tsx
@@ -14,8 +14,8 @@ interface ReportSummaryOwnProps {
   children?: React.ReactNode;
   detailsLink?: React.ReactNode;
   excessActualSpend?: string | React.ReactNode;
-  excessActualSpendBreakdown?: string | React.ReactNode;
   fetchStatus: number | number[];
+  showBreakdown?: boolean;
   subTitle?: MessageDescriptor;
   title: MessageDescriptor;
 }
@@ -29,8 +29,8 @@ const ReportSummaryBase: React.FC<ReportSummaryProps> = ({
   fetchStatus,
   intl,
   excessActualSpend,
-  excessActualSpendBreakdown,
   title,
+  showBreakdown,
   subTitle,
 }) => {
   const isSkeleton = () => {
@@ -53,12 +53,9 @@ const ReportSummaryBase: React.FC<ReportSummaryProps> = ({
             </Title>
             {Boolean(subTitle) && <p style={styles.subtitle}>{intl.formatMessage(subTitle)}</p>}
           </div>
-          {(excessActualSpend !== undefined || excessActualSpendBreakdown !== undefined) && (
+          {excessActualSpend && (
             <div>
-              <ExcessActualSpend
-                excessActualSpend={excessActualSpend}
-                excessActualSpendBreakdown={excessActualSpendBreakdown}
-              />
+              <ExcessActualSpend excessActualSpend={excessActualSpend} showBreakdown={showBreakdown} />
             </div>
           )}
         </div>

--- a/src/routes/utils/dateRange.ts
+++ b/src/routes/utils/dateRange.ts
@@ -4,6 +4,7 @@ import {
   getLastNineMonthsDate,
   getLastSixMonthsDate,
   getLastThreeMonthsDate,
+  getUndefinedDates,
 } from 'utils/dates';
 
 // The date range drop down has the options below (if today is Jan 18th…)
@@ -42,6 +43,6 @@ export const getDateRange = ({
     case DateRangeType.lastThreeMonths:
       return getLastThreeMonthsDate(consumptionDate, isFormatted);
     default:
-      return undefined;
+      return getUndefinedDates();
   }
 };

--- a/src/routes/utils/dateRange.ts
+++ b/src/routes/utils/dateRange.ts
@@ -28,12 +28,11 @@ export const getDateRange = ({
   dateRange,
   consumptionDate,
   contractLineStartDate,
-  contractStartDate,
   isFormatted = false,
 }: DateRangeProps) => {
   switch (dateRange) {
     case DateRangeType.contractedLastYear:
-      return getContractedLastYear(contractLineStartDate, contractStartDate, isFormatted);
+      return getContractedLastYear(contractLineStartDate, isFormatted);
     case DateRangeType.contractedYtd:
       return getContractedYtd(contractLineStartDate, consumptionDate, isFormatted);
     case DateRangeType.lastNineMonths:

--- a/src/store/dashboard/dashboardWidgets.ts
+++ b/src/store/dashboard/dashboardWidgets.ts
@@ -12,9 +12,7 @@ const ActualSpendBreakdown = lazy(
   () => import('routes/overview/components/actual-spend-breakdown/ActualSpendBreakdown')
 );
 const CommittedSpend = lazy(() => import('routes/overview/components/committed-spend/CommittedSpend'));
-const CommittedSpendTrend = lazy(
-  () => import('routes/overview/components/committed-spend-trend-poc/CommittedSpendTrend')
-);
+const CommittedSpendTrend = lazy(() => import('routes/overview/components/committed-spend-trend/CommittedSpendTrend'));
 
 let currrentId = 0;
 const getId = () => currrentId++;
@@ -25,7 +23,7 @@ export const actualSpendWidget: DashboardWidget = {
   id: getId(),
   title: messages.dashboardActualSpendTitle,
   reportPathsType: ReportPathsType.accountSummary,
-  reportType: ReportType.billing,
+  reportType: ReportType.details,
   size: DashboardSize.half,
 };
 
@@ -35,7 +33,7 @@ export const actualSpendBreakdownWidget: DashboardWidget = {
   id: getId(),
   title: messages.dashboardActualSpendBreakdownTitle,
   reportPathsType: ReportPathsType.actualSpendBreakdown,
-  reportType: ReportType.billing,
+  reportType: ReportType.details,
   viewAllPath: formatPath(routes.details.path),
 };
 
@@ -45,7 +43,7 @@ export const committedSpendWidget: DashboardWidget = {
   id: getId(),
   title: messages.dashboardCommitmentSpendTitle,
   reportPathsType: ReportPathsType.accountSummary,
-  reportType: ReportType.billing,
+  reportType: ReportType.details,
   size: DashboardSize.half,
 };
 
@@ -55,6 +53,6 @@ export const committedSpendTrendWidget: DashboardWidget = {
   id: getId(),
   title: messages.dashboardCommitmentSpendTrendTitle,
   reportPathsType: ReportPathsType.details,
-  reportType: ReportType.billing,
+  reportType: ReportType.committedSpend,
   viewAllPath: formatPath(routes.details.path),
 };

--- a/src/store/export/export.test.ts
+++ b/src/store/export/export.test.ts
@@ -26,7 +26,7 @@ const mockExport: Export = {
   },
 } as any;
 
-const reportType = ReportType.billing;
+const reportType = ReportType.details;
 const reportPathsType = ReportPathsType.accountSummary;
 const reportQueryString = 'reportQueryString';
 

--- a/src/store/reports/report.test.ts
+++ b/src/store/reports/report.test.ts
@@ -26,7 +26,7 @@ const mockReport: Report = {
   },
 } as any;
 
-const reportType = ReportType.billing;
+const reportType = ReportType.details;
 const reportPathsType = ReportPathsType.accountSummary;
 const reportQueryString = 'reportQueryString';
 

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -52,8 +52,8 @@ export const formatDate = (startDate, endDate, isFormatted = true) => {
       };
 };
 
-export const getContractedLastYear = (contractLineStartDate: Date, contractStartDate: Date, isFormatted) => {
-  if (contractLineStartDate === undefined || contractStartDate === undefined) {
+export const getContractedLastYear = (contractLineStartDate: Date, isFormatted) => {
+  if (contractLineStartDate === undefined) {
     return { startDate: undefined, endDate: undefined };
   }
   const endDate = new Date(contractLineStartDate.getTime());
@@ -63,10 +63,6 @@ export const getContractedLastYear = (contractLineStartDate: Date, contractStart
   const startDate = new Date(contractLineStartDate.getTime());
   startDate.setFullYear(startDate.getFullYear() - 1);
 
-  // Dates must be within the contract
-  if (contractStartDate > startDate) {
-    return { startDate: undefined, endDate: undefined };
-  }
   return formatDate(startDate, endDate, isFormatted);
 };
 

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -54,7 +54,7 @@ export const formatDate = (startDate, endDate, isFormatted = true) => {
 
 export const getContractedLastYear = (contractLineStartDate: Date, isFormatted) => {
   if (contractLineStartDate === undefined) {
-    return { startDate: undefined, endDate: undefined };
+    return getUndefinedDates();
   }
   const endDate = new Date(contractLineStartDate.getTime());
   endDate.setDate(1); // Workaround to compare month properly
@@ -68,7 +68,7 @@ export const getContractedLastYear = (contractLineStartDate: Date, isFormatted) 
 
 export const getContractedYtd = (contractLineStartDate, consumptionDate, isFormatted) => {
   if (contractLineStartDate === undefined || consumptionDate === undefined) {
-    return { startDate: undefined, endDate: undefined };
+    return getUndefinedDates();
   }
   const endDate = consumptionDate;
   const startDate = new Date(contractLineStartDate.getTime());
@@ -101,7 +101,7 @@ export const getLastThreeMonthsDate = (consumptionDate, isFormatted) => {
 // Returns today's month - offset
 export const getLastMonthsDate = (consumptionDate: Date, offset: number, isFormatted) => {
   if (consumptionDate === undefined) {
-    return { startDate: undefined, endDate: undefined };
+    return getUndefinedDates();
   }
   const endDate = consumptionDate;
   const startDate = new Date();
@@ -115,4 +115,8 @@ export const getLastMonthsDate = (consumptionDate: Date, offset: number, isForma
   }
   startDate.setMonth(endDate.getMonth() - offset);
   return formatDate(startDate, endDate, isFormatted);
+};
+
+export const getUndefinedDates = () => {
+  return { startDate: undefined, endDate: undefined };
 };

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { DateRangeType, getDateRange } from 'routes/utils/dateRange';
 
 export const compareDateYearAndMonth = (a: Date, b: Date) => {
   if (a.getFullYear() > b.getFullYear()) {
@@ -31,7 +32,7 @@ export const getToday = (hrs: number = 0, min: number = 0, sec: number = 0) => {
   return today;
 };
 
-export const getYear = offset => {
+export const getYear = (offset: number) => {
   const today = getToday();
 
   today.setMonth(today.getMonth() + 1); // Adjust to include this month
@@ -40,7 +41,7 @@ export const getYear = offset => {
   return today;
 };
 
-export const formatDate = (startDate, endDate, isFormatted = true) => {
+export const formatDate = (startDate: Date, endDate: Date, isFormatted = true) => {
   return isFormatted
     ? {
         endDate: endDate ? format(endDate, 'yyyy-MM') : undefined,
@@ -52,7 +53,7 @@ export const formatDate = (startDate, endDate, isFormatted = true) => {
       };
 };
 
-export const getContractedLastYear = (contractLineStartDate: Date, isFormatted) => {
+export const getContractedLastYear = (contractLineStartDate: Date, isFormatted: boolean) => {
   if (contractLineStartDate === undefined) {
     return getUndefinedDates();
   }
@@ -66,7 +67,7 @@ export const getContractedLastYear = (contractLineStartDate: Date, isFormatted) 
   return formatDate(startDate, endDate, isFormatted);
 };
 
-export const getContractedYtd = (contractLineStartDate, consumptionDate, isFormatted) => {
+export const getContractedYtd = (contractLineStartDate: Date, consumptionDate: Date, isFormatted: boolean) => {
   if (contractLineStartDate === undefined || consumptionDate === undefined) {
     return getUndefinedDates();
   }
@@ -84,22 +85,22 @@ export const getContractedYtd = (contractLineStartDate, consumptionDate, isForma
 };
 
 // Returns 9 months, including today's date
-export const getLastNineMonthsDate = (consumptionDate, isFormatted) => {
+export const getLastNineMonthsDate = (consumptionDate: Date, isFormatted: boolean) => {
   return getLastMonthsDate(consumptionDate, 8, isFormatted);
 };
 
 // Returns 6 months, including today's date
-export const getLastSixMonthsDate = (consumptionDate, isFormatted) => {
+export const getLastSixMonthsDate = (consumptionDate: Date, isFormatted: boolean) => {
   return getLastMonthsDate(consumptionDate, 5, isFormatted);
 };
 
 // Returns 3 months, including today's date
-export const getLastThreeMonthsDate = (consumptionDate, isFormatted) => {
+export const getLastThreeMonthsDate = (consumptionDate: Date, isFormatted: boolean) => {
   return getLastMonthsDate(consumptionDate, 2, isFormatted);
 };
 
 // Returns today's month - offset
-export const getLastMonthsDate = (consumptionDate: Date, offset: number, isFormatted) => {
+export const getLastMonthsDate = (consumptionDate: Date, offset: number, isFormatted: boolean) => {
   if (consumptionDate === undefined) {
     return getUndefinedDates();
   }
@@ -119,4 +120,12 @@ export const getLastMonthsDate = (consumptionDate: Date, offset: number, isForma
 
 export const getUndefinedDates = () => {
   return { startDate: undefined, endDate: undefined };
+};
+
+export const isContractedLastYearValid = (contractLineStartDate: Date, contractStartDate: Date) => {
+  const { startDate } = getDateRange({
+    dateRange: DateRangeType.contractedLastYear,
+    contractLineStartDate,
+  });
+  return startDate < contractStartDate;
 };


### PR DESCRIPTION
- Fix previous year date range
- Fix order by
- Refactor date range empty states
- Refactor report types to accommodate chart API
- Refactor chart-datum transform to pad using previous month’s value
- Refactor excess spend
- Add comittedSpendChartTrend API