### PR TITLE
Workaround for "null" string in actual spend card

### DIFF
--- a/src/routes/overview/components/actual-spend/ActualSpend.tsx
+++ b/src/routes/overview/components/actual-spend/ActualSpend.tsx
@@ -42,8 +42,12 @@ const ActualSpend: React.FC<ActualSpendProps> = ({ intl, widgetId }) => {
   const hasData = report && report.data && report.data.length;
   const values = hasData && report.data[0];
 
+  // Todo: we shouldn't have to check for "null" strings here -- see HCS-150
   const actualCommittedSpend: string | React.ReactNode =
-    values && values.actual_committed_spend && values.actual_committed_spend.value ? (
+    values &&
+    values.actual_committed_spend &&
+    values.actual_committed_spend.value &&
+    values.actual_committed_spend.value !== 'null' ? (
       formatCurrency(Number(values.actual_committed_spend.value), values.actual_committed_spend.units || 'USD')
     ) : (
       <EmptyValueState />


### PR DESCRIPTION
Workaround for https://issues.redhat.com/browse/HCS-150

The hcsSummary API currently responds with a mix of null and "null" strings, which breaks currency formatting.