### PR TITLE
orderBy should use secondary groupBy

### DIFF
--- a/src/routes/details/utils.ts
+++ b/src/routes/details/utils.ts
@@ -168,7 +168,7 @@ export const useDetailsMapToProps = ({
     },
     ...(queryFromRoute.filter && { filter: queryFromRoute.filter }),
     ...(queryFromRoute.filter_by && { filter_by: queryFromRoute.filter_by }),
-    ...(queryFromRoute.orderBy && { orderBy: queryFromRoute.orderBy }),
+    ...(queryFromRoute.orderBy && { orderBy: secondaryGroupBy ? secondaryGroupBy : queryFromRoute.orderBy }),
     dateRange,
   };
 


### PR DESCRIPTION
The orderBy param of the details API should use secondary groupBy value when available