### PR TITLE
Add PatternFly toolbar components

### DIFF
--- a/src/routes/components/data-toolbar/DataToolbar.scss
+++ b/src/routes/components/data-toolbar/DataToolbar.scss
@@ -7,3 +7,9 @@
     min-width: 250px;
   }
 }
+
+.pf-c-toolbar {
+  &.dataToolbarOverride {
+    --pf-c-toolbar--ZIndex: auto; z-index: 301;
+  }
+}

--- a/src/routes/components/data-toolbar/DataToolbar.tsx
+++ b/src/routes/components/data-toolbar/DataToolbar.tsx
@@ -291,7 +291,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
   }, [groupBy]);
 
   return (
-    <Toolbar clearAllFilters={onDelete as any} collapseListedFiltersBreakpoint="xl">
+    <Toolbar className="dataToolbarOverride" clearAllFilters={onDelete as any} collapseListedFiltersBreakpoint="xl">
       <ToolbarContent>
         <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
           <ToolbarGroup variant="filter-group">

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -1,3 +1,6 @@
+import './detailsHeaderToolbar.scss';
+
+import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import type { DetailsOption } from 'api/options/detailsOption';
 import { OptionPathsType, OptionType } from 'api/options/option';
 import { getQuery } from 'api/queries';
@@ -257,40 +260,50 @@ const DetailsHeaderToolbar: React.FC<DetailsToolbarProps> = ({
   };
 
   return (
-    <div>
-      <Perspective
-        currentItem={sourceOfSpend}
-        id="sourceOfSpendType"
-        label={intl.formatMessage(messages.sourceOfSpendLabel)}
-        minWidth={200}
-        onSelected={handleOnSourceOfSpendSelected}
-        options={getSourceOfSpendOptions()}
-      />
-      <Perspective
-        currentItem={groupBy}
-        id="groupBy"
-        label={intl.formatMessage(messages.groupByLabel)}
-        minWidth={200}
-        onSelected={handleOnGroupBySelected}
-        options={getGroupByOptions(false)}
-      />
-      <Perspective
-        currentItem={secondaryGroupBy}
-        id="secondaryGroupBy"
-        label={intl.formatMessage(messages.secondaryGroupByLabel)}
-        minWidth={200}
-        onSelected={handleOnSecondaryGroupBySelected}
-        options={getGroupByOptions().filter(option => option.value !== groupBy)}
-      />
-      <Perspective
-        currentItem={dateRange}
-        id="dateRange"
-        label={intl.formatMessage(messages.dateRangeLabel)}
-        minWidth={225}
-        onSelected={handleOnDateRangeSelected}
-        options={getDateRangeOptions()}
-      />
-    </div>
+    <Toolbar className="detailsHeaderToolbarOverride">
+      <ToolbarContent>
+        <ToolbarItem>
+          <Perspective
+            currentItem={sourceOfSpend}
+            id="sourceOfSpendType"
+            label={intl.formatMessage(messages.sourceOfSpendLabel)}
+            minWidth={200}
+            onSelected={handleOnSourceOfSpendSelected}
+            options={getSourceOfSpendOptions()}
+          />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Perspective
+            currentItem={groupBy}
+            id="groupBy"
+            label={intl.formatMessage(messages.groupByLabel)}
+            minWidth={200}
+            onSelected={handleOnGroupBySelected}
+            options={getGroupByOptions(false)}
+          />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Perspective
+            currentItem={secondaryGroupBy}
+            id="secondaryGroupBy"
+            label={intl.formatMessage(messages.secondaryGroupByLabel)}
+            minWidth={200}
+            onSelected={handleOnSecondaryGroupBySelected}
+            options={getGroupByOptions().filter(option => option.value !== groupBy)}
+          />
+        </ToolbarItem>
+        <ToolbarItem>
+          <Perspective
+            currentItem={dateRange}
+            id="dateRange"
+            label={intl.formatMessage(messages.dateRangeLabel)}
+            minWidth={225}
+            onSelected={handleOnDateRangeSelected}
+            options={getDateRangeOptions()}
+          />
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
   );
 };
 

--- a/src/routes/details/DetailsTable.scss
+++ b/src/routes/details/DetailsTable.scss
@@ -26,10 +26,6 @@
         // --pf-c-table__expandable-row--after--BorderLeftWidth: 0; // Left blue line for expanded rows
       }
     }
-
-    .pf-c-table__sticky-column {
-      z-index: 99;
-    }
   }
 }
 

--- a/src/routes/details/detailsHeaderToolbar.scss
+++ b/src/routes/details/detailsHeaderToolbar.scss
@@ -1,0 +1,14 @@
+@import url("~@patternfly/patternfly/base/patternfly-variables.css");
+
+.pf-c-toolbar {
+  &.detailsHeaderToolbarOverride {
+    --pf-c-toolbar--ZIndex: auto; z-index: 302;
+
+    .pf-c-toolbar__content {
+      padding: 0;
+    }
+    padding: 0;
+  }
+}
+
+


### PR DESCRIPTION
Wrap details header perspectives with PatternFly toolbar components.
This allows us to set the z-index for each toolbar Vs the z-index on the details table.