### PR TITLE
Update typeahead to use startDate and endDate 

### DIFF
--- a/src/routes/components/data-toolbar/DataToolbar.scss
+++ b/src/routes/components/data-toolbar/DataToolbar.scss
@@ -10,6 +10,7 @@
 
 .pf-c-toolbar {
   &.dataToolbarOverride {
-    --pf-c-toolbar--ZIndex: auto; z-index: 301;
+    // Alternative workaround to overriding table sticky style
+    // --pf-c-toolbar--ZIndex: auto; z-index: 301;
   }
 }

--- a/src/routes/components/data-toolbar/DataToolbar.tsx
+++ b/src/routes/components/data-toolbar/DataToolbar.tsx
@@ -33,6 +33,7 @@ interface Filters {
 }
 
 interface DataToolbarOwnProps {
+  endDate?: Date;
   categoryOptions?: ToolbarChipGroup[]; // Options for category menu
   filterPathsType?: FilterPathsType;
   groupBy?: string; // Sync category selection with groupBy value
@@ -43,11 +44,13 @@ interface DataToolbarOwnProps {
   onFilterRemoved?: (filterType: Filter) => void;
   pagination?: React.ReactNode; // Optional pagination controls to display in toolbar
   query?: Query; // Query containing filter_by params used to restore state upon page refresh
+  startDate?: Date;
 }
 
 type DataToolbarProps = DataToolbarOwnProps;
 
 const DataToolbar: React.FC<DataToolbarProps> = ({
+  endDate,
   categoryOptions,
   filterPathsType,
   groupBy,
@@ -58,6 +61,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
   onFilterRemoved,
   pagination,
   query,
+  startDate,
 }) => {
   const [categoryInput, setCategoryInput] = useState('');
   const [currentCategory, setCurrentCategory] = useState('');
@@ -163,6 +167,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
         <InputGroup>
           {isFilterTypeValid(filterPathsType, categoryOption.key as FilterType) ? (
             <FilterTypeahead
+              endDate={endDate}
               aria-label={intl.formatMessage(messages.filterByInputAriaLabel, { value: categoryOption.key })}
               category={currentCategory}
               filterPathsType={filterPathsType}
@@ -170,6 +175,7 @@ const DataToolbar: React.FC<DataToolbarProps> = ({
               isDisabled={disabled}
               onSelect={value => onCategoryInputSelect(value, categoryOption.key)}
               placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: categoryOption.key })}
+              startDate={startDate}
             />
           ) : (
             <>

--- a/src/routes/components/filterTypeahead/FilterInput.tsx
+++ b/src/routes/components/filterTypeahead/FilterInput.tsx
@@ -27,6 +27,7 @@ import type { ThunkDispatch } from 'redux-thunk';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { filterActions, filterSelectors } from 'store/filters';
+import { formatDate } from 'utils/dates';
 import { useStateCallback } from 'utils/hooks';
 import { noop } from 'utils/noop';
 
@@ -35,6 +36,7 @@ import { styles } from './FilterTypeahead.styles';
 interface FilterInputOwnProps {
   ariaLabel?: string;
   category?: string;
+  endDate?: Date;
   filterPathsType: FilterPathsType;
   filterType: FilterType;
   isDisabled?: boolean;
@@ -43,6 +45,7 @@ interface FilterInputOwnProps {
   onSelect?: (value: string) => void;
   placeholder?: string;
   search?: string;
+  startDate?: Date;
 }
 
 interface FilterInputStateProps {
@@ -59,6 +62,7 @@ type FilterInputProps = FilterInputOwnProps & FilterInputStateProps & FilterInpu
 const FilterInput: React.FC<FilterInputProps> = ({
   ariaLabel,
   category,
+  endDate,
   filterPathsType,
   filterType,
   isDisabled,
@@ -67,6 +71,7 @@ const FilterInput: React.FC<FilterInputProps> = ({
   onSelect,
   search,
   placeholder,
+  startDate,
 }) => {
   const [menuIsOpen, setMenuIsOpen] = useStateCallback(false);
   const intl = useIntl();
@@ -76,9 +81,11 @@ const FilterInput: React.FC<FilterInputProps> = ({
 
   const { filter, filterFetchStatus } = useMapToProps({
     category,
+    endDate,
     filterPathsType,
     filterType,
     search,
+    startDate,
   });
 
   // apply focus to the text input
@@ -226,11 +233,10 @@ const FilterInput: React.FC<FilterInputProps> = ({
   };
 
   const handleClearSearch = () => {
-    setMenuIsOpen(false, () => {
-      if (onClear) {
-        onClear();
-      }
-    });
+    setMenuIsOpen(false);
+    if (onClear) {
+      onClear();
+    }
   };
 
   const openMenu = () => {
@@ -246,9 +252,11 @@ const FilterInput: React.FC<FilterInputProps> = ({
 
 const useMapToProps = ({
   category,
+  endDate,
   filterPathsType,
   filterType,
   search,
+  startDate,
 }: FilterInputOwnProps): FilterInputStateProps => {
   const [searchTimeout, setSearchTimeout] = useState<any>(noop);
 
@@ -258,6 +266,7 @@ const useMapToProps = ({
     filter: {
       [category]: search,
     },
+    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
   } as any;
   const filterQueryString = getQuery(query);
 

--- a/src/routes/components/filterTypeahead/FilterTypeahead.tsx
+++ b/src/routes/components/filterTypeahead/FilterTypeahead.tsx
@@ -7,11 +7,13 @@ import { FilterInput } from './FilterInput';
 interface FilterTypeaheadOwnProps {
   ariaLabel?: string;
   category?: string;
+  endDate?: Date;
   filterPathsType: FilterPathsType;
   filterType: FilterType;
   isDisabled?: boolean;
   onSelect?: (value: string) => void;
   placeholder?: string;
+  startDate?: Date;
 }
 
 type FilterTypeaheadProps = FilterTypeaheadOwnProps;
@@ -21,11 +23,13 @@ type FilterTypeaheadProps = FilterTypeaheadOwnProps;
 const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({
   ariaLabel,
   category,
+  endDate,
   filterPathsType,
   filterType,
   isDisabled,
   onSelect,
   placeholder,
+  startDate,
 }) => {
   const [search, setSearch] = useState<string>(undefined);
 
@@ -46,6 +50,7 @@ const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({
 
   return (
     <FilterInput
+      endDate={endDate}
       ariaLabel={ariaLabel}
       category={category}
       isDisabled={isDisabled}
@@ -56,6 +61,7 @@ const FilterTypeahead: React.FC<FilterTypeaheadProps> = ({
       filterType={filterType}
       placeholder={placeholder}
       search={search}
+      startDate={startDate}
     />
   );
 };

--- a/src/routes/details/Details.tsx
+++ b/src/routes/details/Details.tsx
@@ -90,6 +90,7 @@ const Details: React.FC<DetailsProps> = () => {
   const getFilterToolbar = (isDisabled: boolean) => {
     return (
       <DetailsFilterToolbar
+        endDate={endDate}
         groupBy={groupBy}
         isDisabled={isDisabled}
         isExportDisabled={isDisabled || (report && report.meta && report.meta.count === 0)}
@@ -98,6 +99,7 @@ const Details: React.FC<DetailsProps> = () => {
         onFilterRemoved={handleOnFilterRemoved}
         pagination={getPagination(isDisabled)}
         query={query}
+        startDate={startDate}
       />
     );
   };

--- a/src/routes/details/DetailsFilterToolbar.tsx
+++ b/src/routes/details/DetailsFilterToolbar.tsx
@@ -8,6 +8,7 @@ import { DataToolbar } from 'routes/components/data-toolbar';
 import type { Filter } from 'routes/utils/filter';
 
 interface DetailsFilterToolbarOwnProps {
+  endDate?: Date;
   groupBy: string; // Options for category menu
   isDisabled?: boolean;
   isExportDisabled?: boolean; // Sync category selection with groupBy value
@@ -16,11 +17,13 @@ interface DetailsFilterToolbarOwnProps {
   onFilterRemoved(filter: Filter);
   pagination?: React.ReactNode; // Optional pagination controls to display in toolbar
   query?: Query; // Query containing filter_by params used to restore state upon page refresh
+  startDate?: Date;
 }
 
 type DetailsFilterToolbarProps = DetailsFilterToolbarOwnProps;
 
 const DetailsFilterToolbar: React.FC<DetailsFilterToolbarProps> = ({
+  endDate,
   groupBy,
   isDisabled,
   isExportDisabled,
@@ -29,6 +32,7 @@ const DetailsFilterToolbar: React.FC<DetailsFilterToolbarProps> = ({
   onFilterRemoved,
   pagination,
   query,
+  startDate,
 }) => {
   const intl = useIntl();
   const getCategoryOptions = (): ToolbarChipGroup[] => {
@@ -41,6 +45,7 @@ const DetailsFilterToolbar: React.FC<DetailsFilterToolbarProps> = ({
 
   return (
     <DataToolbar
+      endDate={endDate}
       categoryOptions={getCategoryOptions()}
       filterPathsType={FilterPathsType.detailsFilter}
       groupBy={groupBy}
@@ -51,6 +56,7 @@ const DetailsFilterToolbar: React.FC<DetailsFilterToolbarProps> = ({
       onFilterRemoved={onFilterRemoved}
       pagination={pagination}
       query={query}
+      startDate={startDate}
     />
   );
 };

--- a/src/routes/details/DetailsTable.scss
+++ b/src/routes/details/DetailsTable.scss
@@ -26,6 +26,11 @@
         // --pf-c-table__expandable-row--after--BorderLeftWidth: 0; // Left blue line for expanded rows
       }
     }
+
+    // Alternative workaround to overriding toolbar style
+    .pf-c-table__sticky-column {
+      z-index: 99;
+    }
   }
 }
 

--- a/src/routes/details/detailsHeaderToolbar.scss
+++ b/src/routes/details/detailsHeaderToolbar.scss
@@ -2,7 +2,8 @@
 
 .pf-c-toolbar {
   &.detailsHeaderToolbarOverride {
-    --pf-c-toolbar--ZIndex: auto; z-index: 302;
+    // Alternative workaround to overriding table sticky style
+    // --pf-c-toolbar--ZIndex: auto; z-index: 302;
 
     .pf-c-toolbar__content {
       padding: 0;


### PR DESCRIPTION
- Update typeahead to use startDate and endDate params with details API
- Simplify PatternFly workaround to override table's sticky column z-index