### PR TITLE
Add pagination limit for detailsFilter

### DIFF
--- a/src/routes/components/filterTypeahead/FilterInput.tsx
+++ b/src/routes/components/filterTypeahead/FilterInput.tsx
@@ -265,6 +265,7 @@ const useMapToProps = ({
   const query: Query = {
     filter: {
       [category]: search,
+      limit: 15, // API is paginated by default
     },
     ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
   } as any;


### PR DESCRIPTION
Add pagination limit for detailsFilter. 

The detailsFilter is paginated by default, but we can show 15 items at a time. As the user types, the number of matches will be greatly reduced.