### PR TITLE
Update node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
-sudo: required
-notifications:
-  email: false
+dist: jammy
+sudo: false
 node_js:
-- '16'
+- '18'
 install:
 - npm ci
 jobs:

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export COMPONENT="hybrid-committed-spend"
 export IMAGE="quay.io/cloudservices/hybrid-committed-spend-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=18
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "webpack-bundle-analyzer": "^4.8.0"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "license": "GNU AGPLv3",
   "private": false,
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=18.15.0",
+    "npm": ">=9.5.0"
   },
   "scripts": {
     "build": "npm run build:prod",

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -9,7 +9,7 @@ export COMPONENT="hybrid-committed-spend"
 export IMAGE="quay.io/cloudservices/hybrid-committed-spend-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=18
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -35,7 +35,7 @@ export interface PagedResponseAlt<D = any, M = any> {
  */
 export function initApi({ version }: { version: string }) {
   const insights = (window as any).insights;
-  const env = insights.chrome.isProd() ? '' : '.dev';
+  const env = insights.chrome.isProd() ? '' : '.qa';
 
   axios.defaults.baseURL = `https://billing${env}.api.redhat.com/${version}/`;
   axios.interceptors.request.use(authInterceptor);


### PR DESCRIPTION
Update node to the latest LTS release and `jammy` dist (Ubuntu 22.04)

Note: The Node.js 18 is compatible only with Linux distributions based on glibc 2.28 or later.
In order to use NodeJS 18, install it on a server with supported OS, e.g. Debian 10, RHEL 8, Ubuntu 20.04.

See https://support.plesk.com/hc/en-us/articles/5517433733394--node-or-npm-CLI-commands-on-a-Plesk-server-fail-version-GLIBC-2-28-not-found-required-by-opt-plesk-node-18-bin-node-