### PR TITLE
Revert previous API update

### DIFF
--- a/src/api/export/detailsExport.ts
+++ b/src/api/export/detailsExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/filters/detailsFilter.ts
+++ b/src/api/filters/detailsFilter.ts
@@ -25,12 +25,5 @@ export const FilterTypePaths: Partial<Record<FilterType, string>> = {
 export function runFilter(reportType: FilterType, query: string) {
   const path = FilterTypePaths[reportType];
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<DetailsFilter>(`${path}${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<DetailsFilter>(`${path}${queryString}`);
 }

--- a/src/api/options/detailsOption.ts
+++ b/src/api/options/detailsOption.ts
@@ -21,12 +21,5 @@ export const OptionTypePaths: Partial<Record<OptionType, string>> = {
 export function runOption(reportType: OptionType, query: string) {
   const path = OptionTypePaths[reportType];
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<DetailsOption>(`${path}${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<DetailsOption>(`${path}${queryString}`);
 }

--- a/src/api/reports/accountSummaryReport.ts
+++ b/src/api/reports/accountSummaryReport.ts
@@ -37,12 +37,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<AccountSummaryReport>(`${path}${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AccountSummaryReport>(`${path}${queryString}`);
 }

--- a/src/api/reports/detailsReport.ts
+++ b/src/api/reports/detailsReport.ts
@@ -25,12 +25,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<DetailsReport>(`${path}${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<DetailsReport>(`${path}${queryString}`);
 }

--- a/src/api/user-access/userAccess.ts
+++ b/src/api/user-access/userAccess.ts
@@ -15,12 +15,5 @@ export const enum UserAccessType {
 // If the user-access API is called without a query parameter, all types are returned in the response
 export function fetchUserAccess(query: string) {
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<UserAccess>(`authorization/hcsEnrollment${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<UserAccess>(`authorization/hcsEnrollment${queryString}`);
 }


### PR DESCRIPTION
Reverting previous API update to call insights.chrome.auth.getUser. No longer seems necessary to obtain the user prior to making API requests.