### PR TITLE
Use consumptionDate param for chart APIs

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -16,6 +16,7 @@ export interface Filters {
 export interface Query {
   account?: any;
   affiliate?: any;
+  consumptionDate?: any;
   dateRange?: any;
   endDate?: any;
   product?: any;
@@ -54,14 +55,18 @@ export function convertFilterBy(query: Query) {
   return newQuery;
 }
 
+function alphabeticalSort(a, b) {
+  return a.localeCompare(b);
+}
+
 // filter_by props are converted
 export function getQuery(query: Query) {
-  return stringify(convertFilterBy(query), { encode: false, indices: false });
+  return stringify(convertFilterBy(query), { encode: false, indices: false, sort: alphabeticalSort });
 }
 
 // filter_by props are not converted
 export function getQueryRoute(query: Query) {
-  return stringify(query, { encode: false, indices: false });
+  return stringify(query, { encode: false, indices: false, sort: alphabeticalSort });
 }
 
 // Returns given key without logical OR/AND prefix
@@ -111,6 +116,6 @@ export function parseGroupByPrefix(query: Query) {
 }
 
 export function parseQuery<T = any>(query: string): T {
-  const newQuery = parse(query, { ignoreQueryPrefix: true });
+  const newQuery: any = parse(query, { ignoreQueryPrefix: true });
   return parseFilterByPrefix(parseGroupByPrefix(newQuery));
 }

--- a/src/routes/components/export/ExportSubmit.tsx
+++ b/src/routes/components/export/ExportSubmit.tsx
@@ -73,7 +73,7 @@ const ExportSubmit: React.FC<ExportSubmitProps> = ({
   };
 
   const getFileName = () => {
-    const { endDate: endDateStr, startDate: startDateStr } = formatDate(startDate, endDate, true);
+    const { endDate: endDateStr, startDate: startDateStr } = formatDate({ startDate, endDate });
 
     // File name format: '<groupBy>_<secondaryGroupBy>_<start-date>_<end-date>',
     const fileName = intl.formatMessage(messages.exportFileName, {

--- a/src/routes/components/filterTypeahead/FilterInput.tsx
+++ b/src/routes/components/filterTypeahead/FilterInput.tsx
@@ -267,7 +267,7 @@ const useMapToProps = ({
       [category]: search,
       limit: 15, // API is paginated by default
     },
-    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
+    ...(startDate && endDate && { ...formatDate({ startDate, endDate }) }),
   } as any;
   const filterQueryString = getQuery(query);
 

--- a/src/routes/details/DetailsHeaderToolbar.tsx
+++ b/src/routes/details/DetailsHeaderToolbar.tsx
@@ -314,7 +314,7 @@ const useMapToProps = ({ endDate, startDate }): DetailsHeaderToolbarStateProps =
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
 
   const query = {
-    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
+    ...(startDate && endDate && { ...formatDate({ startDate, endDate }) }),
   };
 
   const optionsQueryString = getQuery(query);

--- a/src/routes/details/utils.ts
+++ b/src/routes/details/utils.ts
@@ -131,7 +131,7 @@ export const useDetailsMapToProps = ({
       ...(query.filter ? query.filter : {}),
       ...(sourceOfSpend !== SourceOfSpendType.all && { source_of_spend: getSourceOfSpendFilter(sourceOfSpend) }),
     },
-    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
+    ...(startDate && endDate && { ...formatDate({ startDate, endDate }) }),
     sourceOfSpend: undefined,
     dateRange: undefined,
   };
@@ -216,7 +216,7 @@ export const useDetailsExpandMapToProps = ({
       ...(sourceOfSpend !== SourceOfSpendType.all && { source_of_spend: getSourceOfSpendFilter(sourceOfSpend) }),
       ...(secondaryGroupBy && { limit: 1000, offset: undefined }), // Children are not paginated
     },
-    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
+    ...(startDate && endDate && { ...formatDate({ startDate, endDate }) }),
     sourceOfSpend: undefined,
     dateRange: undefined,
   };

--- a/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownSummary.tsx
+++ b/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownSummary.tsx
@@ -111,6 +111,7 @@ const useMapToProps = ({
   const widget = useSelector((state: RootState) => dashboardSelectors.selectWidget(state, widgetId));
 
   const { endDate, report, reportError, reportFetchStatus, startDate } = useReportMapDateRangeToProps({
+    consumptionDate,
     contractLineEndDate,
     contractLineStartDate,
     dateRange: DateRangeType.contractedYear,

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendSummary.tsx
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendSummary.tsx
@@ -130,6 +130,7 @@ const useMapToProps = ({
     reportFetchStatus: currentReportFetchStatus,
     startDate: currentStartDate,
   } = useReportMapDateRangeToProps({
+    consumptionDate,
     contractLineEndDate,
     contractLineStartDate,
     dateRange: DateRangeType.contractedYear,

--- a/src/routes/overview/components/utils/report.ts
+++ b/src/routes/overview/components/utils/report.ts
@@ -43,6 +43,7 @@ interface ReportStateProps {
 }
 
 export const useReportMapDateRangeToProps = ({
+  consumptionDate,
   contractLineEndDate,
   contractLineStartDate,
   dateRange,
@@ -63,6 +64,7 @@ export const useReportMapDateRangeToProps = ({
   });
 
   return useReportMapToProps({
+    consumptionDate,
     dateRange,
     endDate,
     limit,
@@ -75,6 +77,7 @@ export const useReportMapDateRangeToProps = ({
 };
 
 export const useReportMapToProps = ({
+  consumptionDate,
   dateRange,
   endDate,
   limit,
@@ -101,7 +104,7 @@ export const useReportMapToProps = ({
 
   const reportQueryString = getQuery({
     ...query,
-    ...(startDate && endDate && { ...formatDate(startDate, endDate) }),
+    ...(startDate && endDate && { ...formatDate({ consumptionDate, startDate, endDate }) }),
     dateRange: undefined,
   });
 

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -5,6 +5,13 @@ export interface DateType {
   startDate: Date;
 }
 
+export interface FormatDate {
+  consumptionDate?: Date;
+  startDate?: Date;
+  endDate?: Date;
+  isFormatted?: boolean;
+}
+
 export const compareDateYearAndMonth = (a: Date, b: Date) => {
   if (a.getFullYear() > b.getFullYear()) {
     return 1;
@@ -45,13 +52,15 @@ export const getYear = (offset: number) => {
   return today;
 };
 
-export const formatDate = (startDate: Date, endDate: Date, isFormatted = true) => {
+export const formatDate = ({ consumptionDate, startDate, endDate, isFormatted = true }: FormatDate) => {
   return isFormatted
     ? {
+        consumptionDate: consumptionDate ? format(consumptionDate, 'yyyy-MM-dd') : undefined,
         endDate: endDate ? format(endDate, 'yyyy-MM-dd') : undefined,
         startDate: startDate ? format(startDate, 'yyyy-MM-dd') : undefined,
       }
     : {
+        consumptionDate,
         endDate,
         startDate,
       };
@@ -65,14 +74,14 @@ export const getContractedLastYear = (
   if (previousContractLineStartDate === undefined || previousContractLineEndDate === undefined) {
     return getUndefinedDates();
   }
-  return formatDate(previousContractLineStartDate, previousContractLineEndDate, isFormatted);
+  return formatDate({ startDate: previousContractLineStartDate, endDate: previousContractLineEndDate, isFormatted });
 };
 
 export const getContractedYear = (contractLineStartDate: Date, contractLineEndDate: Date, isFormatted: boolean) => {
   if (contractLineStartDate === undefined || contractLineEndDate === undefined) {
     return getUndefinedDates();
   }
-  return formatDate(contractLineStartDate, contractLineEndDate, isFormatted);
+  return formatDate({ startDate: contractLineStartDate, endDate: contractLineEndDate, isFormatted });
 };
 
 export const getContractedYtd = (contractLineStartDate: Date, consumptionDate: Date, isFormatted: boolean) => {
@@ -85,7 +94,7 @@ export const getContractedYtd = (contractLineStartDate: Date, consumptionDate: D
   if (!consumptionDate) {
     endDate.setMonth(endDate.getMonth() - 1);
   }
-  return formatDate(startDate, endDate, isFormatted);
+  return formatDate({ startDate, endDate, isFormatted });
 };
 
 // Returns 9 months, including today's date
@@ -118,7 +127,7 @@ export const getLastMonthsDate = (consumptionDate: Date, offset: number, isForma
     endDate.setMonth(endDate.getMonth() - 1);
   }
   startDate.setMonth(endDate.getMonth() - offset);
-  return formatDate(startDate, endDate, isFormatted);
+  return formatDate({ startDate, endDate, isFormatted });
 };
 
 export const getUndefinedDates = () => {


### PR DESCRIPTION
Update the committedSpendTrandChart and actualSpendBreakdownChart API requests to include the consumptionDate parameter for the current contract line. This will ensure actual_spend values are null for all future dates, after the consumption date.

By default, the APIs return a zero value for months where data has not been reported. For cumulative data, the zero would be added to the previous month – that would be carried forward to the next month and so on. We don't want to chart actual_spend values for future dates, but show a "no data" message.

![chrome-capture-2023-3-8](https://user-images.githubusercontent.com/17481322/230744376-831de678-764f-4b66-98cf-ca78be8945b3.gif)
