### PR TITLE
Check fetch status before dispatch

### DIFF
--- a/src/routes/overview/components/utils/report.ts
+++ b/src/routes/overview/components/utils/report.ts
@@ -76,7 +76,6 @@ export const useReportMapDateRangeToProps = ({
 
 export const useReportMapToProps = ({
   consumptionDate,
-  dateRange,
   endDate,
   limit,
   perspective,

--- a/src/store/export/exportActions.tsx
+++ b/src/store/export/exportActions.tsx
@@ -5,7 +5,7 @@ import type { AxiosError } from 'axios';
 import type { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { getFetchId } from 'store/export/exportCommon';
-import { selectExport, selectExportFetchStatus } from 'store/export/exportSelectors';
+import { selectExport, selectExportError, selectExportFetchStatus } from 'store/export/exportSelectors';
 import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
@@ -51,8 +51,9 @@ function isExportExpired(
   reportQueryString: string
 ) {
   const report = selectExport(state, reportPathsType, reportType, reportQueryString);
+  const fetchError = selectExportError(state, reportPathsType, reportType, reportQueryString);
   const fetchStatus = selectExportFetchStatus(state, reportPathsType, reportType, reportQueryString);
-  if (fetchStatus === FetchStatus.inProgress) {
+  if (fetchError || fetchStatus === FetchStatus.inProgress) {
     return false;
   }
 

--- a/src/store/filters/filterActions.ts
+++ b/src/store/filters/filterActions.ts
@@ -8,7 +8,7 @@ import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './filterCommon';
-import { selectFilter, selectFilterFetchStatus } from './filterSelectors';
+import { selectFilter, selectFilterError, selectFilterFetchStatus } from './filterSelectors';
 
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
@@ -52,8 +52,9 @@ function isFilterExpired(
   filterQueryString: string
 ) {
   const filter = selectFilter(state, filterPathsType, filterType, filterQueryString);
+  const fetchError = selectFilterError(state, filterPathsType, filterType, filterQueryString);
   const fetchStatus = selectFilterFetchStatus(state, filterPathsType, filterType, filterQueryString);
-  if (fetchStatus === FetchStatus.inProgress) {
+  if (fetchError || fetchStatus === FetchStatus.inProgress) {
     return false;
   }
 

--- a/src/store/options/optionActions.ts
+++ b/src/store/options/optionActions.ts
@@ -8,7 +8,7 @@ import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './optionCommon';
-import { selectOption, selectOptionFetchStatus } from './optionSelectors';
+import { selectOption, selectOptionError, selectOptionFetchStatus } from './optionSelectors';
 
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
@@ -52,8 +52,9 @@ function isOptionExpired(
   optionQueryString: string
 ) {
   const option = selectOption(state, optionPathsType, optionType, optionQueryString);
+  const fetchError = selectOptionError(state, optionPathsType, optionType, optionQueryString);
   const fetchStatus = selectOptionFetchStatus(state, optionPathsType, optionType, optionQueryString);
-  if (fetchStatus === FetchStatus.inProgress) {
+  if (fetchError || fetchStatus === FetchStatus.inProgress) {
     return false;
   }
 

--- a/src/store/reports/reportActions.ts
+++ b/src/store/reports/reportActions.ts
@@ -7,7 +7,7 @@ import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './reportCommon';
-import { selectReport, selectReportFetchStatus } from './reportSelectors';
+import { selectReport, selectReportError, selectReportFetchStatus } from './reportSelectors';
 
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
@@ -51,8 +51,9 @@ function isReportExpired(
   reportQueryString: string
 ) {
   const report = selectReport(state, reportPathsType, reportType, reportQueryString);
+  const fetchError = selectReportError(state, reportPathsType, reportType, reportQueryString);
   const fetchStatus = selectReportFetchStatus(state, reportPathsType, reportType, reportQueryString);
-  if (fetchStatus === FetchStatus.inProgress) {
+  if (fetchError || fetchStatus === FetchStatus.inProgress) {
     return false;
   }
 

--- a/src/store/user-access/userAccessActions.ts
+++ b/src/store/user-access/userAccessActions.ts
@@ -2,9 +2,11 @@ import type { UserAccess, UserAccessType } from 'api/user-access';
 import { fetchUserAccess as apiGetUserAccess } from 'api/user-access';
 import type { AxiosError } from 'axios';
 import type { ThunkAction } from 'store/common';
+import { FetchStatus } from 'store/common';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './userAccessCommon';
+import { selectUserAccessError, selectUserAccessFetchStatus } from './userAccessSelectors';
 
 interface UserAccessActionMeta {
   fetchId: string;
@@ -15,7 +17,15 @@ export const fetchUserAccessSuccess = createAction('userAccess/fetch/success')<U
 export const fetchUserAccessFailure = createAction('userAccess/fetch/failure')<AxiosError, UserAccessActionMeta>();
 
 export function fetchUserAccess(userAccessType: UserAccessType, userAccessQueryString: string): ThunkAction {
-  return dispatch => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const fetchError = selectUserAccessError(state, userAccessType, userAccessQueryString);
+    const fetchStatus = selectUserAccessFetchStatus(state, userAccessType, userAccessQueryString);
+
+    if (fetchError || fetchStatus === FetchStatus.inProgress) {
+      return;
+    }
+
     const meta: UserAccessActionMeta = {
       fetchId: getFetchId(userAccessType, userAccessQueryString),
     };


### PR DESCRIPTION
If an API errors, the React life cycle could generate another API fetch in some cases. We should to ensure a new fetch is not dispatched, at the Redux actions level, when the fetch status is an error or in-progress.