### PR TITLE
Converted the details table to be compact

### DIFF
--- a/src/routes/details/DetailsTable.scss
+++ b/src/routes/details/DetailsTable.scss
@@ -1,9 +1,5 @@
 @import url("~@patternfly/patternfly/base/patternfly-variables.css");
 
-.firstColumn {
-  --pf-c-table--cell--Width: 1%;
-}
-
 .tableOverride {
   &.pf-c-table {
     tbody th {
@@ -19,8 +15,8 @@
       padding-right: 20px;
     }
     .pf-c-table__expandable-row {
-      --pf-c-table--cell--PaddingTop: var(--pf-c-table--tbody--cell--PaddingTop);
-      --pf-c-table--cell--PaddingBottom: var(--pf-c-table--tbody--cell--PaddingBottom);
+      --pf-c-table--cell--PaddingTop: var(--pf-c-table--m-compact--cell--PaddingTop);
+      --pf-c-table--cell--PaddingBottom: var(--pf-c-table--m-compact--cell--PaddingBottom);
       &.pf-m-expanded > :first-child {
         --pf-c-table--cell--PaddingLeft: 72px;
         // --pf-c-table__expandable-row--after--BorderLeftWidth: 0; // Left blue line for expanded rows
@@ -31,6 +27,9 @@
     .pf-c-table__sticky-column {
       z-index: 99;
     }
+  }
+  .stickyColumn {
+    --pf-c-table--cell--Width: 1%;
   }
 }
 

--- a/src/routes/details/DetailsTable.tsx
+++ b/src/routes/details/DetailsTable.tsx
@@ -277,7 +277,7 @@ const DetailsTable: React.FC<DetailsTableProps> = ({
                     {cells.map((item, cellIndex) =>
                       cellIndex === 0 ? (
                         <Th
-                          className="firstColumn"
+                          className="stickyColumn"
                           dataLabel={columns[cellIndex]}
                           expand={
                             secondaryGroupBy && secondaryGroupBy !== GroupByType.none

--- a/src/routes/details/DetailsTable.tsx
+++ b/src/routes/details/DetailsTable.tsx
@@ -7,6 +7,7 @@ import {
   InnerScrollContainer,
   SortByDirection,
   TableComposable,
+  TableVariant,
   Tbody,
   Td,
   Th,
@@ -231,6 +232,7 @@ const DetailsTable: React.FC<DetailsTableProps> = ({
           aria-label={intl.formatMessage(messages.detailsTableAriaLabel)}
           className="tableOverride"
           gridBreakPoint=""
+          variant={TableVariant.compact}
         >
           <Thead>
             <Tr>


### PR DESCRIPTION
Converted the details table to be compact per Natalie's request.

![Screenshot 2023-05-03 at 7 29 46 PM](https://user-images.githubusercontent.com/17481322/236073132-e533340e-1310-46d5-8adf-1bd3a6acbdc2.png)
