### PR TITLE
Unleash flag to toggle API paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,36 @@
 import './App.scss';
 
+import { Bullseye, Spinner } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import type { Reducer } from 'redux';
 
 import pkg from '../package.json';
+import { initApi } from './api';
 import { useFeatureFlags } from './components/feature-flags';
 import { Routes } from './Routes';
+import type { RootState } from './store';
+import { featureFlagsSelectors } from './store/feature-flags';
 
 const App = () => {
-  const { updateDocumentTitle } = useChrome();
+  const { isProd, updateDocumentTitle } = useChrome();
+
+  const hasFeatureFlags = useSelector((state: RootState) => featureFlagsSelectors.selectHasFeatureFlags(state));
+  const isBillingStageFeatureEnabled = useSelector((state: RootState) =>
+    featureFlagsSelectors.selectIsBillingStageFeatureEnabled(state)
+  );
+
+  useFeatureFlags();
+
+  // Initialize here https://issues.redhat.com/browse/RHCLOUD-25573
+  initApi({
+    isBillingStageFeatureEnabled,
+    version: 'v1',
+  });
 
   useEffect(() => {
     const registry = getRegistry();
@@ -22,8 +40,14 @@ const App = () => {
     updateDocumentTitle(pkg.insights.appname);
   }, []);
 
-  useFeatureFlags();
-
+  // Wait to ensure billing.stage.api.redhat.com APIs are called before defaulting to billing.qa.api.redhat.com domain
+  if (!isProd() && !hasFeatureFlags) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
   return (
     <>
       <NotificationsPortal />

--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -1,5 +1,4 @@
 import IntlProvider from '@redhat-cloud-services/frontend-components-translations/Provider';
-import { initApi } from 'api/api';
 import { getLocale } from 'components/i18n';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -21,11 +20,6 @@ const hcsStore = configureStore({
 
 const AppEntry = () => {
   const locale = getLocale();
-
-  // Initialize here https://issues.redhat.com/browse/RHCLOUD-25573
-  initApi({
-    version: 'v1',
-  });
 
   /* eslint-disable no-console */
   return (

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -32,9 +32,15 @@ export interface PagedResponseAlt<D = any, M = any> {
  * billing.stage.api.redhat.com
  * billing.api.redhat.com
  */
-export function initApi({ version }: { version: string }) {
+export function initApi({
+  isBillingStageFeatureEnabled = false,
+  version,
+}: {
+  isBillingStageFeatureEnabled: boolean;
+  version: string;
+}) {
   const insights = (window as any).insights;
-  const env = insights.chrome.isProd() ? '' : '.qa';
+  const env = insights.chrome.isProd() ? '' : isBillingStageFeatureEnabled ? '.stage' : '.qa';
 
   axios.defaults.baseURL = `https://billing${env}.api.redhat.com/${version}/`;
   axios.interceptors.request.use(authInterceptor);

--- a/src/components/feature-flags/FeatureFlags.tsx
+++ b/src/components/feature-flags/FeatureFlags.tsx
@@ -5,7 +5,7 @@ import { featureFlagsActions } from 'store/feature-flags';
 
 // eslint-disable-next-line no-shadow
 export const enum FeatureToggle {
-  details = 'hybrid-committed-spend.ui.details',
+  billingStage = 'hybrid-committed-spend.ui.billing-stage', // Toggle to enable billing.stage APIs for demos
 }
 
 // The FeatureFlags component saves feature flags in store for places where Unleash hooks not available
@@ -48,8 +48,7 @@ const useFeatureFlags = () => {
       await updateContext({ userId }).then(() => {
         dispatch(
           featureFlagsActions.setFeatureFlags({
-            // Todo: Save for future feature
-            isDetailsFeatureEnabled: client.isEnabled(FeatureToggle.details) || true,
+            isBillingStageFeatureEnabled: client.isEnabled(FeatureToggle.billingStage),
           })
         );
       });

--- a/src/components/permissions/Permissions.tsx
+++ b/src/components/permissions/Permissions.tsx
@@ -8,7 +8,6 @@ import { routes } from 'Routes';
 import { Loading, NotAuthorized, NotAvailable, NotViewable } from 'routes/state';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/feature-flags';
 import { userAccessQuery, userAccessSelectors } from 'store/user-access';
 import { formatPath, usePathname } from 'utils/paths';
 import { hasHcsDataVisibility, hasHcsDeal } from 'utils/userAccess';
@@ -18,7 +17,6 @@ interface PermissionsOwnProps {
 }
 
 interface PermissionsStateProps {
-  isDetailsFeatureEnabled?: boolean;
   userAccess: UserAccess;
   userAccessError: AxiosError;
   userAccessFetchStatus: FetchStatus;
@@ -28,7 +26,7 @@ interface PermissionsStateProps {
 type PermissionsProps = PermissionsOwnProps;
 
 const Permissions: React.FC<PermissionsProps> = ({ children = null }) => {
-  const { isDetailsFeatureEnabled = true, userAccess, userAccessError, userAccessFetchStatus } = useMapToProps();
+  const { userAccess, userAccessError, userAccessFetchStatus } = useMapToProps();
   const pathname = usePathname();
 
   const hasPermissions = () => {
@@ -39,7 +37,7 @@ const Permissions: React.FC<PermissionsProps> = ({ children = null }) => {
 
     switch (pathname) {
       case formatPath(routes.details.path):
-        return hasDeal && isDetailsFeatureEnabled;
+        return hasDeal;
       case formatPath(routes.overview.path):
         return hasDeal;
       default:
@@ -65,10 +63,6 @@ const Permissions: React.FC<PermissionsProps> = ({ children = null }) => {
 };
 
 const useMapToProps = (): PermissionsStateProps => {
-  const isDetailsFeatureEnabled = useSelector((state: RootState) =>
-    featureFlagsSelectors.selectIsDetailsFeatureEnabled(state)
-  );
-
   const userAccessQueryString = getUserAccessQuery(userAccessQuery);
   const userAccess = useSelector((state: RootState) =>
     userAccessSelectors.selectUserAccess(state, UserAccessType.all, userAccessQueryString)
@@ -81,7 +75,6 @@ const useMapToProps = (): PermissionsStateProps => {
   );
 
   return {
-    isDetailsFeatureEnabled,
     userAccess,
     userAccessError,
     userAccessFetchStatus,

--- a/src/store/feature-flags/__snapshots__/featureFlags.test.ts.snap
+++ b/src/store/feature-flags/__snapshots__/featureFlags.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`default state 1`] = `
 {
   "hasFeatureFlags": false,
-  "isDetailsFeatureEnabled": false,
+  "isBillingStageFeatureEnabled": false,
 }
 `;

--- a/src/store/feature-flags/featureFlags.test.ts
+++ b/src/store/feature-flags/featureFlags.test.ts
@@ -14,8 +14,8 @@ test('default state', async () => {
   expect(selectors.selectFeatureFlagsState(store.getState())).toMatchSnapshot();
 });
 
-test('sample feature is enabled', async () => {
+test('Billing stage feature is enabled', async () => {
   const store = createUIStore();
-  store.dispatch(actions.setFeatureFlags({ isDetailsFeatureEnabled: true }));
-  expect(featureFlagsSelectors.selectIsDetailsFeatureEnabled(store.getState())).toBe(true);
+  store.dispatch(actions.setFeatureFlags({ isBillingStageFeatureEnabled: true }));
+  expect(featureFlagsSelectors.selectIsBillingStageFeatureEnabled(store.getState())).toBe(true);
 });

--- a/src/store/feature-flags/featureFlagsActions.ts
+++ b/src/store/feature-flags/featureFlagsActions.ts
@@ -1,7 +1,7 @@
 import { createAction } from 'typesafe-actions';
 
 export interface FeatureFlagsActionMeta {
-  isDetailsFeatureEnabled?: boolean;
+  isBillingStageFeatureEnabled?: boolean;
 }
 
 export const setFeatureFlags = createAction('feature/init_feature_flags')<FeatureFlagsActionMeta>();

--- a/src/store/feature-flags/featureFlagsReducer.ts
+++ b/src/store/feature-flags/featureFlagsReducer.ts
@@ -8,12 +8,12 @@ export type FeatureFlagsAction = ActionType<typeof setFeatureFlags | typeof rese
 
 export type FeatureFlagsState = Readonly<{
   hasFeatureFlags: boolean;
-  isDetailsFeatureEnabled: boolean;
+  isBillingStageFeatureEnabled: boolean;
 }>;
 
 export const defaultState: FeatureFlagsState = {
   hasFeatureFlags: false,
-  isDetailsFeatureEnabled: false,
+  isBillingStageFeatureEnabled: false,
 };
 
 export const stateKey = 'featureFlags';
@@ -24,7 +24,7 @@ export function featureFlagsReducer(state = defaultState, action: FeatureFlagsAc
       return {
         ...state,
         hasFeatureFlags: true,
-        isDetailsFeatureEnabled: action.payload.isDetailsFeatureEnabled,
+        isBillingStageFeatureEnabled: action.payload.isBillingStageFeatureEnabled,
       };
 
     default:

--- a/src/store/feature-flags/featureFlagsSelectors.ts
+++ b/src/store/feature-flags/featureFlagsSelectors.ts
@@ -6,5 +6,5 @@ export const selectFeatureFlagsState = (state: RootState) => state[stateKey];
 
 export const selectHasFeatureFlags = (state: RootState) => selectFeatureFlagsState(state).hasFeatureFlags;
 
-export const selectIsDetailsFeatureEnabled = (state: RootState) =>
-  selectFeatureFlagsState(state).isDetailsFeatureEnabled;
+export const selectIsBillingStageFeatureEnabled = (state: RootState) =>
+  selectFeatureFlagsState(state).isBillingStageFeatureEnabled;


### PR DESCRIPTION
Created an Unleash flag to toggle API paths between billing.qa.api.redhat.com and billing.stage.api.redhat.com. This flag will be enabled for a specific user account yet to be determined. 

Ultimately, this will be used to help test data in IT's stage environment.

https://issues.redhat.com/browse/HCS-203