### PR TITLE
Update basename for Subscriptions bundle

### DIFF
--- a/src/components/page-title/PageTitle.tsx
+++ b/src/components/page-title/PageTitle.tsx
@@ -2,7 +2,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { routes } from 'Routes';
-import { formatPath, usePathname } from 'utils/paths';
+import { useFormatPath, usePathname } from 'utils/paths';
 
 interface PageTitleOwnProps {
   children?: React.ReactNode;
@@ -11,6 +11,7 @@ interface PageTitleOwnProps {
 type PageTitleProps = PageTitleOwnProps;
 
 const PageTitle: React.FC<PageTitleProps> = ({ children = null }) => {
+  const formatPath = useFormatPath;
   const pathname = usePathname();
   const intl = useIntl();
 

--- a/src/components/permissions/Permissions.tsx
+++ b/src/components/permissions/Permissions.tsx
@@ -9,7 +9,7 @@ import { Loading, NotAuthorized, NotAvailable, NotViewable } from 'routes/state'
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { userAccessQuery, userAccessSelectors } from 'store/user-access';
-import { formatPath, usePathname } from 'utils/paths';
+import { useFormatPath, usePathname } from 'utils/paths';
 import { hasHcsDataVisibility, hasHcsDeal } from 'utils/userAccess';
 
 interface PermissionsOwnProps {
@@ -27,6 +27,7 @@ type PermissionsProps = PermissionsOwnProps;
 
 const Permissions: React.FC<PermissionsProps> = ({ children = null }) => {
   const { userAccess, userAccessError, userAccessFetchStatus } = useMapToProps();
+  const formatPath = useFormatPath;
   const pathname = usePathname();
 
   const hasPermissions = () => {

--- a/src/routes/components/page-heading/PageHeading.tsx
+++ b/src/routes/components/page-heading/PageHeading.tsx
@@ -14,7 +14,7 @@ import { EmptyValueState } from 'routes/components/state/empty-value';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
-import { formatPath, usePathname } from 'utils/paths';
+import { useFormatPath, usePathname } from 'utils/paths';
 
 import { styles } from './PageHeading.styles';
 
@@ -33,6 +33,7 @@ type PageHeadingProps = PageHeadingOwnProps;
 
 const PageHeading: React.FC<PageHeadingProps> = ({ children }) => {
   const { report, reportFetchStatus } = useMapToProps();
+  const formatPath = useFormatPath;
   const pathname = usePathname();
   const intl = useIntl();
 

--- a/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownSummary.tsx
+++ b/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownSummary.tsx
@@ -17,6 +17,7 @@ import type { DashboardWidget } from 'store/dashboard';
 import { dashboardSelectors } from 'store/dashboard';
 import { getToday } from 'utils/dates';
 import { formatCurrency } from 'utils/format';
+import { useFormatPath } from 'utils/paths';
 
 import { ResolutionType } from './ActualSpendBreakdown';
 import { ActualSpendBreakdownTransform } from './ActualSpendBreakdownTransform';
@@ -54,6 +55,7 @@ const ActualSpendBreakdownSummary: React.FC<ActualSpendBreakdownSummaryProps> = 
     resolution,
     widgetId,
   });
+  const formatPath = useFormatPath;
   const intl = useIntl();
 
   const hasData = report && report.meta;
@@ -67,7 +69,7 @@ const ActualSpendBreakdownSummary: React.FC<ActualSpendBreakdownSummaryProps> = 
 
   const getDetailsLink = () => {
     if (widget.viewAllPath) {
-      const href = `${widget.viewAllPath}?${getQuery({
+      const href = `${formatPath(widget.viewAllPath)}?${getQuery({
         // TBD...
       })}`;
       return <Link to={href}>{intl.formatMessage(messages.viewDetails)}</Link>;

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendSummary.tsx
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendSummary.tsx
@@ -17,6 +17,7 @@ import type { DashboardWidget } from 'store/dashboard';
 import { dashboardSelectors } from 'store/dashboard';
 import { getToday } from 'utils/dates';
 import { formatCurrency } from 'utils/format';
+import { useFormatPath } from 'utils/paths';
 
 import { PerspectiveType } from './CommittedSpendTrend';
 import { CommittedSpendTrendTransform } from './CommittedSpendTrendTransform';
@@ -64,6 +65,7 @@ const CommittedSpendTrendSummary: React.FC<CommittedSpendTrendSummaryProps> = ({
     perspective,
     widgetId,
   });
+  const formatPath = useFormatPath;
   const intl = useIntl();
 
   const hasData = currentReport && currentReport.meta;
@@ -77,7 +79,7 @@ const CommittedSpendTrendSummary: React.FC<CommittedSpendTrendSummaryProps> = ({
 
   const getDetailsLink = () => {
     if (widget.viewAllPath) {
-      const href = `${widget.viewAllPath}?${getQuery({
+      const href = `${formatPath(widget.viewAllPath)}?${getQuery({
         // TBD...
       })}`;
       return <Link to={href}>{intl.formatMessage(messages.viewDetails)}</Link>;

--- a/src/routes/state/not-authorized/NotAuthorizedState.tsx
+++ b/src/routes/state/not-authorized/NotAuthorizedState.tsx
@@ -3,7 +3,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { routes } from 'Routes';
-import { formatPath } from 'utils/paths';
+import { useFormatPath } from 'utils/paths';
 
 interface NotAuthorizedStateOwnProps {
   pathname?: string;
@@ -12,6 +12,7 @@ interface NotAuthorizedStateOwnProps {
 type NotAuthorizedStateProps = NotAuthorizedStateOwnProps;
 
 const NotAuthorizedState: React.FC<NotAuthorizedStateProps> = ({ pathname }) => {
+  const formatPath = useFormatPath;
   const intl = useIntl();
 
   let msg;

--- a/src/routes/state/not-viewable/NotViewableState.tsx
+++ b/src/routes/state/not-viewable/NotViewableState.tsx
@@ -4,7 +4,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { routes } from 'Routes';
-import { formatPath } from 'utils/paths';
+import { useFormatPath } from 'utils/paths';
 
 interface NotViewableStateOwnProps {
   pathname?: string;
@@ -13,6 +13,7 @@ interface NotViewableStateOwnProps {
 type NotViewableStateProps = NotViewableStateOwnProps;
 
 const NotViewableState: React.FC<NotViewableStateProps> = ({ pathname }) => {
+  const formatPath = useFormatPath;
   const intl = useIntl();
 
   let title;

--- a/src/store/dashboard/dashboardWidgets.ts
+++ b/src/store/dashboard/dashboardWidgets.ts
@@ -2,7 +2,6 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { lazy } from 'react';
 import { routes } from 'Routes';
-import { formatPath } from 'utils/paths';
 
 import type { DashboardWidget } from './dashboardCommon';
 import { DashboardSize } from './dashboardCommon';
@@ -32,7 +31,7 @@ export const actualSpendBreakdownWidget: DashboardWidget = {
   title: messages.dashboardActualSpendBreakdownTitle,
   reportPathsType: ReportPathsType.details,
   reportType: ReportType.actualSpend,
-  viewAllPath: formatPath(routes.details.path),
+  viewAllPath: routes.details.path,
 };
 
 export const committedSpendWidget: DashboardWidget = {
@@ -52,5 +51,5 @@ export const committedSpendTrendWidget: DashboardWidget = {
   title: messages.dashboardCommitmentSpendTrendTitle,
   reportPathsType: ReportPathsType.details,
   reportType: ReportType.committedSpend,
-  viewAllPath: formatPath(routes.details.path),
+  viewAllPath: routes.details.path,
 };

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,13 +1,14 @@
 import { useLocation } from 'react-router-dom';
 import { routes } from 'Routes';
 
-// Prefixes the given path with a basename
-//
+// eslint-disable-next-line no-restricted-imports
+import pkg from '../../package.json';
+
 // Note the basename does not include a release prefix (/beta, /preview, etc.), unlike the getBaseName function from
 // @redhat-cloud-services/frontend-components-utilities/helpers
-export const formatPath = path => {
-  const basename = '/business-services/hybrid-committed-spend';
-  return path === routes.overview.path ? basename : `${basename}${path}`;
+export const getBasename = pathname => {
+  const index = pathname ? pathname.indexOf(pkg.insights.appname) + pkg.insights.appname.length : 0;
+  return index <= pathname.length ? pathname.substring(0, index) : ''; // '/business-services/hybrid-committed-spend'
 };
 
 export const getReleasePath = () => {
@@ -22,6 +23,13 @@ export const getReleasePath = () => {
     release = `/preview`;
   }
   return release;
+};
+
+// Prefixes the given path with a basename
+export const useFormatPath = path => {
+  const pathname = usePathname();
+  const basename = getBasename(pathname);
+  return path === routes.overview.path ? basename : `${basename}${path}`;
 };
 
 export const usePathname = () => {

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -4,13 +4,6 @@ import { routes } from 'Routes';
 // eslint-disable-next-line no-restricted-imports
 import pkg from '../../package.json';
 
-// Note the basename does not include a release prefix (/beta, /preview, etc.), unlike the getBaseName function from
-// @redhat-cloud-services/frontend-components-utilities/helpers
-export const getBasename = pathname => {
-  const index = pathname ? pathname.indexOf(pkg.insights.appname) + pkg.insights.appname.length : 0;
-  return index <= pathname.length ? pathname.substring(0, index) : ''; // '/business-services/hybrid-committed-spend'
-};
-
 export const getReleasePath = () => {
   const pathName = window.location.pathname.split('/');
   pathName.shift();
@@ -25,15 +18,21 @@ export const getReleasePath = () => {
   return release;
 };
 
+// Note the basename does not include a release prefix (/beta, /preview, etc.), unlike the getBaseName function from
+// @redhat-cloud-services/frontend-components-utilities/helpers
+export const useBasename = () => {
+  const pathname = usePathname();
+  const index = pathname ? pathname.indexOf(pkg.insights.appname) + pkg.insights.appname.length : 0;
+  return index <= pathname.length ? pathname.substring(0, index) : ''; // '/business-services/hybrid-committed-spend'
+};
+
 // Prefixes the given path with a basename
 export const useFormatPath = path => {
-  const pathname = usePathname();
-  const basename = getBasename(pathname);
+  const basename = useBasename();
   return path === routes.overview.path ? basename : `${basename}${path}`;
 };
 
 export const usePathname = () => {
   const location = useLocation();
-
   return location.pathname.replace(/\/$/, '');
 };


### PR DESCRIPTION
ConsoleDot is in the process of adding the HCS UI to the Subscriptions bundle. Currently users cannot view pages because the UI doesn't recognize the new "subscriptions/hybrid-committed-spend" path. We need to update the basename.

https://issues.redhat.com/browse/HCS-221