### PR TITLE
Dependabot branch separator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,5 @@ updates:
       - "dependency-bot"
     commit-message:
       prefix: "(chore)"
+    pull-request-branch-name:
+      separator: "_"


### PR DESCRIPTION
Workaround for slashes in branch name

See https://issues.redhat.com/browse/RHCLOUD-27539