### PR TITLE
Refactor charts to use PatternFly's legendAllowWrap function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GNU AGPLv3",
       "dependencies": {
         "@patternfly/patternfly": "^5.1.0",
-        "@patternfly/react-charts": "^7.1.1",
+        "@patternfly/react-charts": "^7.2.0-prerelease.2",
         "@patternfly/react-core": "^5.1.1",
         "@patternfly/react-icons": "^5.1.1",
         "@patternfly/react-table": "^5.1.1",
@@ -2202,12 +2202,12 @@
       "integrity": "sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA=="
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-7.1.1.tgz",
-      "integrity": "sha512-X5T+wlbh+sNKIVScx3ykivu1+EIEcQvEdjv6vfyBlsBU8CzACgMRQff4buBL6um3Zv2kT4LPefd6zxoaerJdkg==",
+      "version": "7.2.0-prerelease.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-7.2.0-prerelease.2.tgz",
+      "integrity": "sha512-K+oTb5u9SthknZ7ui+0+RJGMOtLMNl3bV7pn65jivOhLgAd8aFenPX5iGJIbI2PmkMhwv2y90N0/DLbmI/dPfQ==",
       "dependencies": {
-        "@patternfly/react-styles": "^5.1.1",
-        "@patternfly/react-tokens": "^5.1.1",
+        "@patternfly/react-styles": "^5.2.0-prerelease.1",
+        "@patternfly/react-tokens": "^5.2.0-prerelease.1",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.19",
         "tslib": "^2.5.0",
@@ -2233,6 +2233,16 @@
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
+    },
+    "node_modules/@patternfly/react-charts/node_modules/@patternfly/react-styles": {
+      "version": "5.2.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.2.0-prerelease.1.tgz",
+      "integrity": "sha512-jIMOdMkwFuQsNUiw5755WjeABRbN9Wv5djj/39Hz64ICmDZ1FHF/RMyjR1ssGSFt6nmPScgoWrFUkPyAT7BabA=="
+    },
+    "node_modules/@patternfly/react-charts/node_modules/@patternfly/react-tokens": {
+      "version": "5.2.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.2.0-prerelease.1.tgz",
+      "integrity": "sha512-yqVFYsDIuGXSnSLwn7/pUW363StWjasc8jAUIDWUQ9PwidMv8Vp4TLdZ9QwycwNlkZyl+TVHroU0+2Oylkjhvw=="
     },
     "node_modules/@patternfly/react-component-groups": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "^5.1.0",
-    "@patternfly/react-charts": "^7.1.1",
+    "@patternfly/react-charts": "^7.2.0-prerelease.2",
     "@patternfly/react-core": "^5.1.1",
     "@patternfly/react-icons": "^5.1.1",
     "@patternfly/react-table": "^5.1.1",

--- a/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownChart.styles.ts
+++ b/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownChart.styles.ts
@@ -2,7 +2,6 @@ import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg'
 
 export const chartStyles = {
   chartHeight: 265,
-  chartContainerHeight: 265,
 };
 
 export const styles = {

--- a/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownChart.tsx
+++ b/src/routes/overview/components/actual-spend-breakdown/ActualSpendBreakdownChart.tsx
@@ -14,9 +14,7 @@ const ActualSpendBreakdownChart: React.FC<ActualSpendBreakdownChartProps> = ({ c
   const getChart = () => {
     return (
       <BreakdownChart
-        adjustContainerHeight
-        containerHeight={chartStyles.chartContainerHeight}
-        height={chartStyles.chartHeight}
+        baseHeight={chartStyles.chartHeight}
         name={chartName}
         top1stData={data.length > 0 ? data[0] : []}
         top2ndData={data.length > 1 ? data[1] : []}

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendChart.styles.ts
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendChart.styles.ts
@@ -2,7 +2,6 @@ import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg'
 
 export const chartStyles = {
   chartHeight: 265,
-  chartContainerHeight: 265,
 };
 
 export const styles = {

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendChart.tsx
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendChart.tsx
@@ -20,10 +20,8 @@ const CommittedSpendTrendChart: React.FC<CommittedSpendTrendChartProps> = ({
 }) => {
   return (
     <TrendChart
-      adjustContainerHeight
-      containerHeight={chartStyles.chartContainerHeight}
+      baseHeight={chartStyles.chartHeight}
       currentData={currentData}
-      height={chartStyles.chartHeight}
       name={chartName}
       thresholdData={thresholdData}
     />

--- a/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendOverChart.tsx
+++ b/src/routes/overview/components/committed-spend-trend/CommittedSpendTrendOverChart.tsx
@@ -21,10 +21,8 @@ const CommittedSpendTrendOverChart: React.FC<CommittedSpendTrendOverChartProps> 
 }) => {
   return (
     <TrendChart
-      adjustContainerHeight
-      containerHeight={chartStyles.chartContainerHeight}
+      baseHeight={chartStyles.chartHeight}
       currentData={currentData}
-      height={chartStyles.chartHeight}
       name={chartName}
       previousData={previousData}
       thresholdData={thresholdData}


### PR DESCRIPTION
Refactor usage chart to use PatternFly's chart legendAllowWrap function

Note: Build won't succeed without an update to the PatternFly chart package.

https://issues.redhat.com/browse/HCS-245

![chrome-capture-2023-9-8](https://github.com/RedHatInsights/hybrid-committed-spend-ui/assets/17481322/35c02f8e-b95b-474a-9e23-8e9445a09991)
