### PR TITLE
[HCS-260] Enable unit test run on push event on main branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,9 @@ name: Pull request
 on:
   pull_request:
     branches: [ main, master, prod-beta, prod-stable, stage-beta, stage-stable ]
+  push:
+    branches:
+      - main
 env:
   BRANCH: ${{ github.base_ref }}
 


### PR DESCRIPTION
Enabling unit test run against main branch.
- To collect unit test count for QE metrics
- To collect code-coverage against main branch

https://app.codecov.io/gh/RedHatInsights/hybrid-committed-spend-ui