### PR TITLE
Add missinge servicesTitles entry

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -11,6 +11,14 @@ objects:
       name: hybrid-committed-spend
     spec:
       feoConfigEnabled: true
+      serviceTiles:
+        - id: 'hybrid-committed-spend'
+          section: 'subscriptions'
+          group: 'subscriptions'
+          title: 'Hybrid Committed Spend'
+          href: '/subscriptions/hybrid-committed-spend'
+          description: 'Gain perspective on your Hybrid Committed Spend profile with contract information, drawdown, and balance, as well as spend trends and breakdowns.'
+          icon: OpenShiftIcon
       searchEntries:
         - id: 'hybrid-committed-spend'
           title: 'Hybrid Committed Spend'


### PR DESCRIPTION
As part of the FEO migration, our frontend.yaml needs a serviceTiles entry to appear on the "all services" page.

https://issues.redhat.com/browse/HCS-279